### PR TITLE
Add reflection-based CRUD SQL builder and service

### DIFF
--- a/Crud/CrudService.cs
+++ b/Crud/CrudService.cs
@@ -1,0 +1,151 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+
+/// <summary>
+/// Default implementation of <see cref="ICrudService"/> which delegates SQL generation to
+/// <see cref="ICrudSqlBuilder"/> and execution to <see cref="IDbExecutor"/>.
+/// </summary>
+public class CrudService : ICrudService
+{
+    private readonly ICrudSqlBuilder _builder;
+    private readonly IDbExecutor _db;
+
+    public CrudService(ICrudSqlBuilder builder, IDbExecutor db)
+    {
+        _builder = builder;
+        _db = db;
+    }
+
+    public async Task<int> InsertAsync(string table, object dto, CancellationToken ct = default)
+    {
+        var (sql, param) = _builder.BuildInsert(table, dto);
+        try
+        {
+            return await _db.ExecuteAsync(sql, param, ct: ct);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to execute INSERT.", ex);
+        }
+    }
+
+    public async Task<T?> InsertOutputAsync<T>(string table, object dto, string identityColumn, CancellationToken ct = default)
+    {
+        var (sql, param) = _builder.BuildInsertOutput(table, dto, identityColumn);
+        try
+        {
+            return await _db.ExecuteScalarAsync<T>(sql, param, ct: ct);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to execute INSERT with OUTPUT.", ex);
+        }
+    }
+
+    public async Task<int> UpdateAsync(string table, object setDto, object whereDto, CancellationToken ct = default)
+    {
+        var (sql, param) = _builder.BuildUpdate(table, setDto, whereDto);
+        try
+        {
+            return await _db.ExecuteAsync(sql, param, ct: ct);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to execute UPDATE.", ex);
+        }
+    }
+
+    public async Task<int> DeleteAsync(string table, object whereDto, CancellationToken ct = default)
+    {
+        var (sql, param) = _builder.BuildDelete(table, whereDto);
+        try
+        {
+            return await _db.ExecuteAsync(sql, param, ct: ct);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to execute DELETE.", ex);
+        }
+    }
+
+    public async Task<bool> ExistsAsync(string table, object whereDto, CancellationToken ct = default)
+    {
+        var (sql, param) = _builder.BuildExists(table, whereDto);
+        try
+        {
+            var result = await _db.ExecuteScalarAsync<int?>(sql, param, ct: ct);
+            return result.HasValue;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to execute EXISTS.", ex);
+        }
+    }
+
+    public async Task<int> InsertAsync(SqlConnection conn, SqlTransaction? tx, string table, object dto, CancellationToken ct = default)
+    {
+        var (sql, param) = _builder.BuildInsert(table, dto);
+        try
+        {
+            return await _db.ExecuteAsync(conn, tx, sql, param, ct: ct);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to execute INSERT.", ex);
+        }
+    }
+
+    public async Task<T?> InsertOutputAsync<T>(SqlConnection conn, SqlTransaction? tx, string table, object dto, string identityColumn, CancellationToken ct = default)
+    {
+        var (sql, param) = _builder.BuildInsertOutput(table, dto, identityColumn);
+        try
+        {
+            return await _db.ExecuteScalarAsync<T>(conn, tx, sql, param, ct: ct);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to execute INSERT with OUTPUT.", ex);
+        }
+    }
+
+    public async Task<int> UpdateAsync(SqlConnection conn, SqlTransaction? tx, string table, object setDto, object whereDto, CancellationToken ct = default)
+    {
+        var (sql, param) = _builder.BuildUpdate(table, setDto, whereDto);
+        try
+        {
+            return await _db.ExecuteAsync(conn, tx, sql, param, ct: ct);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to execute UPDATE.", ex);
+        }
+    }
+
+    public async Task<int> DeleteAsync(SqlConnection conn, SqlTransaction? tx, string table, object whereDto, CancellationToken ct = default)
+    {
+        var (sql, param) = _builder.BuildDelete(table, whereDto);
+        try
+        {
+            return await _db.ExecuteAsync(conn, tx, sql, param, ct: ct);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to execute DELETE.", ex);
+        }
+    }
+
+    public async Task<bool> ExistsAsync(SqlConnection conn, SqlTransaction? tx, string table, object whereDto, CancellationToken ct = default)
+    {
+        var (sql, param) = _builder.BuildExists(table, whereDto);
+        try
+        {
+            var result = await _db.ExecuteScalarAsync<int?>(conn, tx, sql, param, ct: ct);
+            return result.HasValue;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to execute EXISTS.", ex);
+        }
+    }
+}

--- a/Crud/CrudSqlBuilder.cs
+++ b/Crud/CrudSqlBuilder.cs
@@ -1,0 +1,173 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using Dapper;
+
+/// <summary>
+/// Reflection based implementation of <see cref="ICrudSqlBuilder"/>.
+/// Responsible for generating parameterized SQL statements without touching I/O.
+/// </summary>
+public class CrudSqlBuilder : ICrudSqlBuilder
+{
+    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> _propertiesCache = new();
+    private static readonly Regex _safeIdentRegex = new("^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Validates identifier text and wraps it with brackets to avoid injection.
+    /// </summary>
+    /// <param name="ident">Identifier string.</param>
+    /// <returns>Safe identifier.</returns>
+    /// <exception cref="ArgumentException">Thrown when identifier is invalid.</exception>
+    public static string SafeIdent(string ident)
+    {
+        if (string.IsNullOrWhiteSpace(ident) || !_safeIdentRegex.IsMatch(ident))
+        {
+            throw new ArgumentException($"Invalid identifier '{ident}'.", nameof(ident));
+        }
+        return $"[{ident}]";
+    }
+
+    /// <summary>
+    /// Qualifies table name with optional schema.
+    /// </summary>
+    public string Qualified(string table)
+    {
+        var parts = table.Split('.');
+        var builder = new StringBuilder();
+        for (int i = 0; i < parts.Length; i++)
+        {
+            if (i > 0) builder.Append('.');
+            builder.Append(SafeIdent(parts[i]));
+        }
+        return builder.ToString();
+    }
+
+    /// <inheritdoc />
+    public (string Sql, DynamicParameters Params) BuildInsert(string table, object dto)
+    {
+        try
+        {
+            var props = GetProperties(dto);
+            var columns = string.Join(",", props.Select(p => SafeIdent(p.Name)));
+            var parameters = string.Join(",", props.Select(p => "@" + p.Name));
+            var sql = $"INSERT INTO {Qualified(table)} ({columns}) VALUES ({parameters});";
+            var dp = new DynamicParameters(dto);
+            return (sql, dp);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to build INSERT SQL.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public (string Sql, DynamicParameters Params) BuildInsertOutput(string table, object dto, string identityColumn)
+    {
+        try
+        {
+            var props = GetProperties(dto);
+            var columns = string.Join(",", props.Select(p => SafeIdent(p.Name)));
+            var parameters = string.Join(",", props.Select(p => "@" + p.Name));
+            var sql = $"INSERT INTO {Qualified(table)} ({columns}) OUTPUT INSERTED.{SafeIdent(identityColumn)} VALUES ({parameters});";
+            var dp = new DynamicParameters(dto);
+            return (sql, dp);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to build INSERT SQL.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public (string Sql, DynamicParameters Params) BuildUpdate(string table, object setDto, object whereDto)
+    {
+        try
+        {
+            var dp = new DynamicParameters();
+            var setClause = BuildSet(setDto, dp);
+            var whereClause = BuildWhere(whereDto, dp);
+            var sql = $"UPDATE {Qualified(table)} SET {setClause} WHERE {whereClause};";
+            return (sql, dp);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to build UPDATE SQL.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public (string Sql, DynamicParameters Params) BuildDelete(string table, object whereDto)
+    {
+        try
+        {
+            var dp = new DynamicParameters();
+            var whereClause = BuildWhere(whereDto, dp);
+            var sql = $"DELETE FROM {Qualified(table)} WHERE {whereClause};";
+            return (sql, dp);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to build DELETE SQL.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public (string Sql, DynamicParameters Params) BuildExists(string table, object whereDto)
+    {
+        try
+        {
+            var dp = new DynamicParameters();
+            var whereClause = BuildWhere(whereDto, dp);
+            var sql = $"SELECT 1 FROM {Qualified(table)} WHERE {whereClause};";
+            return (sql, dp);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to build EXISTS SQL.", ex);
+        }
+    }
+
+    private static string BuildSet(object setDto, DynamicParameters parameters)
+    {
+        var props = GetProperties(setDto);
+        if (props.Length == 0)
+        {
+            throw new ArgumentException("setDto has no properties.", nameof(setDto));
+        }
+        var assignments = new List<string>(props.Length);
+        foreach (var p in props)
+        {
+            var paramName = $"set_{p.Name}";
+            assignments.Add($"{SafeIdent(p.Name)}=@{paramName}");
+            parameters.Add(paramName, p.GetValue(setDto));
+        }
+        return string.Join(",", assignments);
+    }
+
+    /// <summary>
+    /// Builds WHERE clause and appends parameters with <c>w_</c> prefix.
+    /// </summary>
+    private static string BuildWhere(object whereDto, DynamicParameters parameters)
+    {
+        var props = GetProperties(whereDto);
+        if (props.Length == 0)
+        {
+            throw new ArgumentException("whereDto has no properties.", nameof(whereDto));
+        }
+        var conditions = new List<string>(props.Length);
+        foreach (var p in props)
+        {
+            var paramName = $"w_{p.Name}";
+            conditions.Add($"{SafeIdent(p.Name)}=@{paramName}");
+            parameters.Add(paramName, p.GetValue(whereDto));
+        }
+        return string.Join(" AND ", conditions);
+    }
+
+    private static PropertyInfo[] GetProperties(object dto)
+    {
+        var type = dto.GetType();
+        return _propertiesCache.GetOrAdd(type, t => t.GetProperties(BindingFlags.Instance | BindingFlags.Public));
+    }
+}

--- a/Crud/ICrudService.cs
+++ b/Crud/ICrudService.cs
@@ -1,0 +1,21 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+
+/// <summary>
+/// Provides high level CRUD operations by delegating SQL generation to <see cref="ICrudSqlBuilder"/>
+/// and execution to <see cref="IDbExecutor"/>.
+/// </summary>
+public interface ICrudService
+{
+    Task<int> InsertAsync(string table, object dto, CancellationToken ct = default);
+    Task<T?> InsertOutputAsync<T>(string table, object dto, string identityColumn, CancellationToken ct = default);
+    Task<int> UpdateAsync(string table, object setDto, object whereDto, CancellationToken ct = default);
+    Task<int> DeleteAsync(string table, object whereDto, CancellationToken ct = default);
+    Task<bool> ExistsAsync(string table, object whereDto, CancellationToken ct = default);
+
+    Task<int> InsertAsync(SqlConnection conn, SqlTransaction? tx, string table, object dto, CancellationToken ct = default);
+    Task<T?> InsertOutputAsync<T>(SqlConnection conn, SqlTransaction? tx, string table, object dto, string identityColumn, CancellationToken ct = default);
+    Task<int> UpdateAsync(SqlConnection conn, SqlTransaction? tx, string table, object setDto, object whereDto, CancellationToken ct = default);
+    Task<int> DeleteAsync(SqlConnection conn, SqlTransaction? tx, string table, object whereDto, CancellationToken ct = default);
+    Task<bool> ExistsAsync(SqlConnection conn, SqlTransaction? tx, string table, object whereDto, CancellationToken ct = default);
+}

--- a/Crud/ICrudSqlBuilder.cs
+++ b/Crud/ICrudSqlBuilder.cs
@@ -1,0 +1,50 @@
+using Dapper;
+
+/// <summary>
+/// Builds parameterized SQL statements for basic CRUD operations.
+/// </summary>
+public interface ICrudSqlBuilder
+{
+    /// <summary>
+    /// Builds an INSERT statement.
+    /// </summary>
+    /// <param name="table">Target table name.</param>
+    /// <param name="dto">DTO containing column values.</param>
+    /// <returns>SQL text and parameters.</returns>
+    (string Sql, DynamicParameters Params) BuildInsert(string table, object dto);
+
+    /// <summary>
+    /// Builds an INSERT statement that outputs the generated identity value.
+    /// </summary>
+    /// <typeparam name="T">Type of the identity column.</typeparam>
+    /// <param name="table">Target table name.</param>
+    /// <param name="dto">DTO containing column values.</param>
+    /// <param name="identityColumn">Identity column name to return.</param>
+    /// <returns>SQL text and parameters.</returns>
+    (string Sql, DynamicParameters Params) BuildInsertOutput(string table, object dto, string identityColumn);
+
+    /// <summary>
+    /// Builds an UPDATE statement with a WHERE clause.
+    /// </summary>
+    /// <param name="table">Target table name.</param>
+    /// <param name="setDto">DTO containing values to update.</param>
+    /// <param name="whereDto">DTO describing WHERE conditions. Supports composite keys via property names.</param>
+    /// <returns>SQL text and parameters.</returns>
+    (string Sql, DynamicParameters Params) BuildUpdate(string table, object setDto, object whereDto);
+
+    /// <summary>
+    /// Builds a DELETE statement.
+    /// </summary>
+    /// <param name="table">Target table name.</param>
+    /// <param name="whereDto">DTO describing WHERE conditions. Supports composite keys via property names.</param>
+    /// <returns>SQL text and parameters.</returns>
+    (string Sql, DynamicParameters Params) BuildDelete(string table, object whereDto);
+
+    /// <summary>
+    /// Builds an EXISTS statement returning 1 when rows satisfying the condition exist.
+    /// </summary>
+    /// <param name="table">Target table name.</param>
+    /// <param name="whereDto">DTO describing WHERE conditions. Supports composite keys via property names.</param>
+    /// <returns>SQL text and parameters.</returns>
+    (string Sql, DynamicParameters Params) BuildExists(string table, object whereDto);
+}

--- a/DcMateH5Api.Tests/Crud/CrudServiceTests.cs
+++ b/DcMateH5Api.Tests/Crud/CrudServiceTests.cs
@@ -1,0 +1,59 @@
+using System.Data;
+using Dapper;
+using Moq;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+public class CrudServiceTests
+{
+    [Fact]
+    public async Task InsertAsync_PassesSqlAndParams()
+    {
+        var builder = new CrudSqlBuilder();
+        var dto = new { Name = "A" };
+        var expected = builder.BuildInsert("Users", dto);
+        var mockDb = new Mock<IDbExecutor>();
+        mockDb.Setup(d => d.ExecuteAsync(expected.Sql, expected.Params, null, CommandType.Text, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(1)
+              .Verifiable();
+        var svc = new CrudService(builder, mockDb.Object);
+        var result = await svc.InsertAsync("Users", dto, CancellationToken.None);
+        Assert.Equal(1, result);
+        mockDb.Verify();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithTransaction_PassesSqlAndParams()
+    {
+        var builder = new CrudSqlBuilder();
+        var mockDb = new Mock<IDbExecutor>();
+        var setDto = new { Name = "B" };
+        var whereDto = new { Id = 2 };
+        var expected = builder.BuildUpdate("Users", setDto, whereDto);
+        mockDb.Setup(d => d.ExecuteAsync(It.IsAny<SqlConnection>(), It.IsAny<SqlTransaction?>(), expected.Sql, It.Is<object>(p => p is DynamicParameters), null, CommandType.Text, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(1)
+              .Verifiable();
+        var svc = new CrudService(builder, mockDb.Object);
+        using var conn = new SqlConnection();
+        SqlTransaction? tx = null;
+        var result = await svc.UpdateAsync(conn, tx, "Users", setDto, whereDto, CancellationToken.None);
+        Assert.Equal(1, result);
+        mockDb.Verify();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_ReturnsBool()
+    {
+        var builder = new CrudSqlBuilder();
+        var whereDto = new { Id = 3 };
+        var expected = builder.BuildExists("Users", whereDto);
+        var mockDb = new Mock<IDbExecutor>();
+        mockDb.Setup(d => d.ExecuteScalarAsync<int?>(expected.Sql, expected.Params, null, CommandType.Text, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(1)
+              .Verifiable();
+        var svc = new CrudService(builder, mockDb.Object);
+        var exists = await svc.ExistsAsync("Users", whereDto, CancellationToken.None);
+        Assert.True(exists);
+        mockDb.Verify();
+    }
+}

--- a/DcMateH5Api.Tests/Crud/CrudSqlBuilderTests.cs
+++ b/DcMateH5Api.Tests/Crud/CrudSqlBuilderTests.cs
@@ -1,0 +1,36 @@
+using Dapper;
+using Xunit;
+
+public class CrudSqlBuilderTests
+{
+    [Fact]
+    public void SafeIdent_Valid_ReturnsBracketed()
+    {
+        var result = CrudSqlBuilder.SafeIdent("Users");
+        Assert.Equal("[Users]", result);
+    }
+
+    [Fact]
+    public void SafeIdent_Invalid_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => CrudSqlBuilder.SafeIdent("bad name"));
+    }
+
+    [Fact]
+    public void BuildDelete_ComposesCompositeWhere()
+    {
+        var builder = new CrudSqlBuilder();
+        var (sql, _) = builder.BuildDelete("Users", new { Id = 1, Code = "A" });
+        Assert.Contains("WHERE [Id]=@w_Id AND [Code]=@w_Code", sql);
+    }
+
+    [Fact]
+    public void BuildUpdate_UsesPrefixedParameters()
+    {
+        var builder = new CrudSqlBuilder();
+        var (sql, param) = builder.BuildUpdate("Users", new { Name = "B" }, new { Id = 1 });
+        var dp = Assert.IsType<DynamicParameters>(param);
+        Assert.Contains("set_Name", dp.ParameterNames);
+        Assert.Contains("w_Id", dp.ParameterNames);
+    }
+}

--- a/README-CRUD.md
+++ b/README-CRUD.md
@@ -1,0 +1,60 @@
+# CRUD Helpers
+
+This module provides a lightweight reflection-based SQL builder and service wrapper for basic CRUD operations. SQL strings are generated with parameterization and identifier validation, while execution is delegated to an existing `IDbExecutor`.
+
+## Usage
+
+```csharp
+var builder = new CrudSqlBuilder();
+var crud = new CrudService(builder, _dbExecutor);
+
+// insert
+await crud.InsertAsync("Users", new { Name = "Alice" }, ct);
+
+// update
+await crud.UpdateAsync("Users", new { Name = "Bob" }, new { Id = 1 }, ct);
+
+// delete
+await crud.DeleteAsync("Users", new { Id = 1 }, ct);
+
+// exists
+bool exists = await crud.ExistsAsync("Users", new { Id = 1 }, ct);
+```
+
+### Using transactions
+
+```csharp
+await _dbExecutor.TxAsync(async (conn, tx, ct) =>
+{
+    await crud.InsertAsync(conn, tx, "Users", new { Name = "Tx" }, ct);
+    await crud.UpdateAsync(conn, tx, "Users", new { Name = "Tx2" }, new { Id = 2 }, ct);
+});
+```
+
+## Diagnostics
+
+Common errors and their meanings:
+
+* `ArgumentException: setDto has no properties.` – update called with empty DTO.
+* `ArgumentException: whereDto has no properties.` – delete/update/exists without WHERE conditions is blocked.
+* `Invalid identifier` – table or column name failed validation.
+
+## Safety checklist
+
+* Identifiers are validated by `SafeIdent` to avoid injection.
+* All values are passed as Dapper parameters.
+* Update and delete require WHERE conditions.
+* Parameter names for SET and WHERE use `set_`/`w_` prefixes to avoid collisions.
+
+## Bug guards
+
+* DTOs with no public properties raise `ArgumentException`.
+* Schema-qualified table names are supported via `Qualified`.
+* Exceptions from database execution are wrapped with operation context for easier diagnostics.
+
+## Performance notes
+
+* Reflection results are cached in a `ConcurrentDictionary` keyed by type.
+* Only necessary string allocations are performed when building SQL.
+* No I/O occurs during building; service performs execution.
+```


### PR DESCRIPTION
## Summary
- add `CrudSqlBuilder` and `ICrudSqlBuilder` for generating parameterized SQL for insert, update, delete, and exists operations
- add `CrudService` that executes generated SQL through `IDbExecutor` with transactional and non-transactional overloads
- add README and unit tests demonstrating identifier safety and parameter passing

## Testing
- `dotnet test -l "console;verbosity=minimal"` *(fails: Microsoft.Build.Exceptions.InternalLoggerException: TerminalLogger WrapText ArgumentOutOfRangeException)*

------
https://chatgpt.com/codex/tasks/task_e_68a428a094288320b7dea6e2f336b15d