### PR TITLE
refactor: async form designer view model

### DIFF
--- a/Areas/Form/Controllers/FormDesignerController.cs
+++ b/Areas/Form/Controllers/FormDesignerController.cs
@@ -6,6 +6,7 @@ using DcMateH5Api.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using DcMateH5Api.Helper;
+using System.Threading;
 
 namespace DcMateH5Api.Areas.Form.Controllers;
 
@@ -60,9 +61,9 @@ public class FormDesignerController : ControllerBase
     /// </summary>
     // [RequirePermission(ActionAuthorizeHelper.View)]
     [HttpGet("{id:guid}")]
-    public IActionResult GetDesigner(Guid id)
+    public async Task<IActionResult> GetDesigner(Guid id, CancellationToken ct)
     {
-        var model = _formDesignerService.GetFormDesignerIndexViewModel(id);
+        var model = await _formDesignerService.GetFormDesignerIndexViewModel(id, ct);
         return Ok(model);
     }
 

--- a/Areas/Form/Controllers/FormDesignerMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormDesignerMasterDetailController.cs
@@ -5,6 +5,7 @@ using DcMateH5Api.Areas.Form.ViewModels;
 using DcMateH5Api.Areas.Security.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using DcMateH5Api.Helper;
+using System.Threading;
 
 namespace DcMateH5Api.Areas.Form.Controllers;
 
@@ -59,9 +60,9 @@ public class FormDesignerMasterDetailController : ControllerBase
     /// </summary>
     // [RequirePermission(ActionAuthorizeHelper.View)]
     [HttpGet("{id:guid}")]
-    public IActionResult GetDesigner(Guid id)
+    public async Task<IActionResult> GetDesigner(Guid id, CancellationToken ct)
     {
-        var model = _formDesignerService.GetFormDesignerIndexViewModel(id);
+        var model = await _formDesignerService.GetFormDesignerIndexViewModel(id, ct);
         return Ok(model);
     }
 

--- a/Areas/Form/Interfaces/IFormDesignerService.cs
+++ b/Areas/Form/Interfaces/IFormDesignerService.cs
@@ -1,6 +1,7 @@
 using DcMateH5Api.Areas.Form.Models;
 using ClassLibrary;
 using DcMateH5Api.Areas.Form.ViewModels;
+using System.Threading;
 
 namespace DcMateH5Api.Areas.Form.Interfaces;
 
@@ -9,7 +10,7 @@ public interface IFormDesignerService
     Task<List<FORM_FIELD_Master>> GetFormMasters(CancellationToken ct);
     void DeleteFormMaster(Guid id);
     
-    FormDesignerIndexViewModel GetFormDesignerIndexViewModel(Guid? id);
+    Task<FormDesignerIndexViewModel> GetFormDesignerIndexViewModel(Guid? id, CancellationToken ct);
     
     /// <summary>
     /// 依名稱關鍵字查詢資料表或檢視表名稱清單。

--- a/DcMateH5Api.Tests/ApiControllerTest/FormDesignerControllerTests.cs
+++ b/DcMateH5Api.Tests/ApiControllerTest/FormDesignerControllerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using DcMateH5Api.Helper;
 using System.Net;
+using System.Threading;
 
 namespace DcMateH5Api.Tests.ApiControllerTest;
 
@@ -22,14 +23,16 @@ public class FormDesignerControllerTests
         => new FormDesignerController(_designerMock.Object);
 
     [Fact]
-    public void GetDesigner_ReturnsViewModel()
+    public async Task GetDesigner_ReturnsViewModel()
     {
         var id = Guid.NewGuid();
         var vm = new FormDesignerIndexViewModel();
-        _designerMock.Setup(s => s.GetFormDesignerIndexViewModel(id)).Returns(vm);
+        _designerMock
+            .Setup(s => s.GetFormDesignerIndexViewModel(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(vm);
         var controller = CreateController();
 
-        var result = controller.GetDesigner(id) as OkObjectResult;
+        var result = await controller.GetDesigner(id, CancellationToken.None) as OkObjectResult;
 
         Assert.NotNull(result);
         Assert.Equal(vm, result.Value);


### PR DESCRIPTION
## Summary
- async FormDesignerService.GetFormDesignerIndexViewModel using SQL helper
- update controllers and interface to await new async API
- adjust unit test for async controller action

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0c5430248320ba7ecc175adcf4de