### PR TITLE
refactor: separate form name update

### DIFF
--- a/Areas/Form/Controllers/FormDesignerController.cs
+++ b/Areas/Form/Controllers/FormDesignerController.cs
@@ -67,7 +67,7 @@ public class FormDesignerController : ControllerBase
     [HttpPut("form-name")]
     public async Task<IActionResult> UpdateFormName([FromBody] UpdateFormNameViewModel model, CancellationToken ct)
     {
-        await _formDesignerService.UpdateFormName(model.Id, model.FormName, ct);
+        await _formDesignerService.UpdateFormName(model.ID, model.FORM_NAME, ct);
         return Ok();
     }
     

--- a/Areas/Form/Controllers/FormDesignerController.cs
+++ b/Areas/Form/Controllers/FormDesignerController.cs
@@ -60,6 +60,16 @@ public class FormDesignerController : ControllerBase
         await _formDesignerService.UpdateFormMaster(model, ct);
         return Ok();
     }
+
+    /// <summary>
+    /// 更新表單名稱
+    /// </summary>
+    [HttpPut("form-name")]
+    public async Task<IActionResult> UpdateFormName([FromBody] UpdateFormNameViewModel model, CancellationToken ct)
+    {
+        await _formDesignerService.UpdateFormName(model.Id, model.FormName, ct);
+        return Ok();
+    }
     
     /// <summary>
     /// 刪除指定的表單主檔資料。
@@ -109,11 +119,11 @@ public class FormDesignerController : ControllerBase
     /// 取得資料表所有欄位設定(如果傳入空formMasterId，會創建一筆新的，如果有傳入，會取得舊的)
     /// </summary>
     [HttpGet("tables/{tableName}/fields")]
-    public IActionResult GetFields(string tableName, Guid? formMasterId, string formName, [FromQuery] TableSchemaQueryType schemaType)
+    public IActionResult GetFields(string tableName, Guid? formMasterId, [FromQuery] TableSchemaQueryType schemaType)
     {
         try
         {
-            var result = _formDesignerService.EnsureFieldsSaved(tableName, formMasterId, schemaType, formName);
+            var result = _formDesignerService.EnsureFieldsSaved(tableName, formMasterId, schemaType);
 
             if (result == null)
             {

--- a/Areas/Form/Controllers/FormDesignerMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormDesignerMasterDetailController.cs
@@ -22,5 +22,4 @@ public class FormDesignerMasterDetailController : ControllerBase
     {
         _formDesignerService = formDesignerService;
     }
-  
 }

--- a/Areas/Form/Interfaces/IFormDesignerService.cs
+++ b/Areas/Form/Interfaces/IFormDesignerService.cs
@@ -29,9 +29,10 @@ public interface IFormDesignerService
     FormFieldListViewModel? EnsureFieldsSaved(
         string tableName,
         Guid? formMasterId,
-        TableSchemaQueryType type,
-        string? formName = null);
+        TableSchemaQueryType type);
     FormFieldListViewModel GetFieldsByTableName(string tableName, Guid? formMasterId, TableSchemaQueryType schemaType);
+
+    Task UpdateFormName(Guid id, string formName, CancellationToken ct);
 
     /// <summary>
     /// 依欄位設定 ID 取得單一欄位設定。

--- a/Areas/Form/Services/FormDesignerService.cs
+++ b/Areas/Form/Services/FormDesignerService.cs
@@ -381,8 +381,8 @@ public class FormDesignerService : IFormDesignerService
         // 重新查一次所有欄位，確保資料同步
         var result = GetFieldsByTableName(tableName, masterId, schemaType);
 
-        var master = _con.QueryFirst<FORM_FIELD_Master>(Sql.FormMasterById, new { id = masterId });
-        result.formName = master.FORM_NAME;
+        // var master = _con.QueryFirst<FORM_FIELD_Master>(Sql.FormMasterById, new { id = masterId });
+        // result.formName = master.FORM_NAME;
         
         // 對於檢視表，先預設有下拉選單的設定，創建的ISUSESQL欄位會為NULL
         if (schemaType == TableSchemaQueryType.OnlyView)

--- a/Areas/Form/ViewModels/FormFieldListViewModel.cs
+++ b/Areas/Form/ViewModels/FormFieldListViewModel.cs
@@ -10,7 +10,7 @@ public class FormFieldListViewModel
     /// </summary>
     public Guid ID { get; set; }
     
-    public string? formName { get; set; } = string.Empty;
+    // public string? formName { get; set; } = string.Empty;
     public string TableName { get; set; } = string.Empty;
 
     public TableSchemaQueryType SchemaQueryType { get; set; }

--- a/Areas/Form/ViewModels/UpdateFormNameViewModel.cs
+++ b/Areas/Form/ViewModels/UpdateFormNameViewModel.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace DcMateH5Api.Areas.Form.ViewModels
+{
+    public class UpdateFormNameViewModel
+    {
+        public Guid Id { get; set; }
+        public string FormName { get; set; } = string.Empty;
+    }
+}
+

--- a/Areas/Form/ViewModels/UpdateFormNameViewModel.cs
+++ b/Areas/Form/ViewModels/UpdateFormNameViewModel.cs
@@ -4,8 +4,8 @@ namespace DcMateH5Api.Areas.Form.ViewModels
 {
     public class UpdateFormNameViewModel
     {
-        public Guid Id { get; set; }
-        public string FormName { get; set; } = string.Empty;
+        public Guid ID { get; set; }
+        public string FORM_NAME { get; set; } = string.Empty;
     }
 }
 

--- a/DcMateH5Api.Tests/ApiControllerTest/FormDesignerControllerTests.cs
+++ b/DcMateH5Api.Tests/ApiControllerTest/FormDesignerControllerTests.cs
@@ -110,14 +110,28 @@ public class FormDesignerControllerTests
     {
         var controller = CreateController();
         _designerMock
-            .Setup(s => s.EnsureFieldsSaved("T", null, TableSchemaQueryType.OnlyTable, "F"))
+            .Setup(s => s.EnsureFieldsSaved("T", null, TableSchemaQueryType.OnlyTable))
             .Throws(new HttpStatusCodeException(HttpStatusCode.BadRequest, "缺少必要欄位"));
 
-        var result = controller.GetFields("T", null, "F", TableSchemaQueryType.OnlyTable);
+        var result = controller.GetFields("T", null, TableSchemaQueryType.OnlyTable);
 
         var obj = Assert.IsType<ObjectResult>(result);
         Assert.Equal((int)HttpStatusCode.BadRequest, obj.StatusCode);
         Assert.Equal("缺少必要欄位", obj.Value);
+    }
+
+    [Fact]
+    public async Task UpdateFormName_ReturnsOk()
+    {
+        var controller = CreateController();
+        var vm = new UpdateFormNameViewModel { Id = Guid.NewGuid(), FormName = "N" };
+        _designerMock
+            .Setup(s => s.UpdateFormName(vm.Id, vm.FormName, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await controller.UpdateFormName(vm, CancellationToken.None);
+
+        Assert.IsType<OkResult>(result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- remove `formName` parameter from `GetFields`
- add dedicated endpoint for updating form names
- ensure new form masters start with empty names

## Testing
- `dotnet test` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b906ed3e9c832090d8067f6850dfee