### PR TITLE
feat: add master detail form header support

### DIFF
--- a/Areas/Form/Controllers/FormController.cs
+++ b/Areas/Form/Controllers/FormController.cs
@@ -39,7 +39,7 @@ public class FormController : ControllerBase
     /// <param name="conditions">查詢條件</param>
     /// <returns>查詢結果</returns>
     [HttpPost("search")]
-    public IActionResult GetForms([FromBody] List<FormQueryCondition>? conditions)
+    public IActionResult GetForms([FromBody] FormSearchRequest conditions)
     {
         var vm = _formService.GetFormList(conditions);
         return Ok(vm);

--- a/Areas/Form/Controllers/FormDesignerController.cs
+++ b/Areas/Form/Controllers/FormDesignerController.cs
@@ -17,7 +17,8 @@ namespace DcMateH5Api.Areas.Form.Controllers;
 public class FormDesignerController : ControllerBase
 {
     private readonly IFormDesignerService _formDesignerService;
-
+    private readonly FormFunctionType _funcType = FormFunctionType.NotMasterDetail;
+    
     public FormDesignerController(
         IFormDesignerService formDesignerService)
     {
@@ -26,43 +27,36 @@ public class FormDesignerController : ControllerBase
 
     // ────────── Form Designer 列表 ──────────
     /// <summary>
-    /// 取得所有表單主檔清單，可透過關鍵字進行模糊搜尋。
+    /// 取得表單主檔 (FORM_FIELD_Master) 清單
     /// </summary>
-    /// <param name="schemaType">必填，表單 Schema 類型</param>
-    /// <param name="q">可選的搜尋關鍵字，將比對 FORM_NAME</param>
+    /// <param name="q">關鍵字 (模糊搜尋 FORM_NAME)</param>
+    /// <param name="ct">CancellationToken</param>
+    /// <returns>表單主檔清單</returns>
     [HttpGet]
     public async Task<ActionResult<List<FORM_FIELD_Master>>> GetFormMasters(
-        [FromQuery] TableSchemaQueryType schemaType,
         [FromQuery] string? q,
         CancellationToken ct)
     {
-        var list = await _formDesignerService.GetFormMasters(schemaType, ct);
+        var masters = await _formDesignerService.GetFormMasters(_funcType, q, ct);
 
-        if (!string.IsNullOrWhiteSpace(q))
-        {
-            list = list
-                .Where(x => x.FORM_NAME.Contains(q, StringComparison.OrdinalIgnoreCase))
-                .ToList();
-        }
-
-        return Ok(list);
+        return Ok(masters.ToList());
     }
     
-    /// <summary>
-    /// 更新單筆主表or檢視表名稱
-    /// </summary>
-    /// <param name="model"></param>
-    /// <param name="ct"></param>
-    /// <returns></returns>
-    [HttpPut]
-    public async Task<IActionResult> UpdateFormMaster([FromBody] FORM_FIELD_Master model, CancellationToken ct)
-    {
-        await _formDesignerService.UpdateFormMaster(model, ct);
-        return Ok();
-    }
+    // /// <summary>
+    // /// 更新單筆主表or檢視表名稱
+    // /// </summary>
+    // /// <param name="model"></param>
+    // /// <param name="ct"></param>
+    // /// <returns></returns>
+    // [HttpPut]
+    // public async Task<IActionResult> UpdateFormMaster([FromBody] FORM_FIELD_Master model, CancellationToken ct)
+    // {
+    //     await _formDesignerService.UpdateFormMaster(model, ct);
+    //     return Ok();
+    // }
 
     /// <summary>
-    /// 更新表單名稱
+    /// 更新主檔 or 明細 or 檢視表 名稱
     /// </summary>
     [HttpPut("form-name")]
     public async Task<IActionResult> UpdateFormName([FromBody] UpdateFormNameViewModel model, CancellationToken ct)
@@ -72,7 +66,7 @@ public class FormDesignerController : ControllerBase
     }
     
     /// <summary>
-    /// 刪除指定的表單主檔資料。
+    /// 刪除指定的主檔 or 明細 or 檢視表資料
     /// </summary>
     /// <param name="id">FORM_FIELD_Master 的唯一識別編號</param>
     /// <returns>NoContent 回應</returns>
@@ -85,13 +79,13 @@ public class FormDesignerController : ControllerBase
     
     // ────────── Form Designer 入口 ──────────
     /// <summary>
-    /// 取得指定表單的設計器主畫面資料(請傳入父節點 masterId)
+    /// 取得指定的 主檔 and 檢視表 主畫面資料(請傳入父節點 masterId)
     /// </summary>
     // [RequirePermission(ActionAuthorizeHelper.View)]
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> GetDesigner(Guid id, CancellationToken ct)
     {
-        var model = await _formDesignerService.GetFormDesignerIndexViewModel(id, ct);
+        var model = await _formDesignerService.GetFormDesignerIndexViewModel(_funcType, id, ct);
         return Ok(model);
     }
 

--- a/Areas/Form/Controllers/FormDesignerController.cs
+++ b/Areas/Form/Controllers/FormDesignerController.cs
@@ -409,6 +409,22 @@ public class FormDesignerController : ControllerBase
         return Ok(new { id });
     }
 
+    /// <summary>
+    /// 儲存 Master/Detail 表單主檔資訊
+    /// </summary>
+    [HttpPost("headers/master-detail")]
+    public IActionResult SaveMasterDetailFormHeader([FromBody] MasterDetailFormHeaderViewModel model)
+    {
+        if (model.MASTER_TABLE_ID == Guid.Empty || model.DETAIL_TABLE_ID == Guid.Empty || model.VIEW_TABLE_ID == Guid.Empty)
+            return BadRequest("MASTER_TABLE_ID / DETAIL_TABLE_ID / VIEW_TABLE_ID 不可為空");
+
+        if (_formDesignerService.CheckMasterDetailFormMasterExists(model.MASTER_TABLE_ID, model.DETAIL_TABLE_ID, model.VIEW_TABLE_ID, model.ID))
+            return Conflict("相同的 Master/Detail/View 組合已存在");
+
+        var id = _formDesignerService.SaveMasterDetailFormHeader(model);
+        return Ok(new { id });
+    }
+
     // ────────── Util ──────────
     // private List<ValidationTypeOptionDto> GetValidationTypeOptions(Guid fieldId)
     // {

--- a/Areas/Form/Controllers/FormDesignerController.cs
+++ b/Areas/Form/Controllers/FormDesignerController.cs
@@ -409,22 +409,6 @@ public class FormDesignerController : ControllerBase
         return Ok(new { id });
     }
 
-    /// <summary>
-    /// 儲存 Master/Detail 表單主檔資訊
-    /// </summary>
-    [HttpPost("headers/master-detail")]
-    public IActionResult SaveMasterDetailFormHeader([FromBody] MasterDetailFormHeaderViewModel model)
-    {
-        if (model.MASTER_TABLE_ID == Guid.Empty || model.DETAIL_TABLE_ID == Guid.Empty || model.VIEW_TABLE_ID == Guid.Empty)
-            return BadRequest("MASTER_TABLE_ID / DETAIL_TABLE_ID / VIEW_TABLE_ID 不可為空");
-
-        if (_formDesignerService.CheckMasterDetailFormMasterExists(model.MASTER_TABLE_ID, model.DETAIL_TABLE_ID, model.VIEW_TABLE_ID, model.ID))
-            return Conflict("相同的 Master/Detail/View 組合已存在");
-
-        var id = _formDesignerService.SaveMasterDetailFormHeader(model);
-        return Ok(new { id });
-    }
-
     // ────────── Util ──────────
     // private List<ValidationTypeOptionDto> GetValidationTypeOptions(Guid fieldId)
     // {

--- a/Areas/Form/Controllers/FormDesignerController.cs
+++ b/Areas/Form/Controllers/FormDesignerController.cs
@@ -92,7 +92,7 @@ public class FormDesignerController : ControllerBase
     // ────────── 欄位相關 ──────────
 
     /// <summary>
-    /// 依表名稱關鍵字搜尋實表或檢視表，並回傳列表。
+    /// 依表名稱關鍵字搜尋 表 或 檢視表，並回傳列表。
     /// </summary>
     [HttpGet("tables/tableName")]
     public IActionResult SearchTables(string? tableName, [FromQuery] TableSchemaQueryType schemaType)
@@ -110,7 +110,7 @@ public class FormDesignerController : ControllerBase
     }
     
     /// <summary>
-    /// 取得資料表所有欄位設定(如果傳入空formMasterId，會創建一筆新的，如果有傳入，會取得舊的)
+    /// 取得資料表所有欄位設定(tableName必須傳，如果傳入空formMasterId，會創建一筆新的，如果有傳入formMasterId，會取得舊的)
     /// </summary>
     [HttpGet("tables/{tableName}/fields")]
     public IActionResult GetFields(string tableName, Guid? formMasterId, [FromQuery] TableSchemaQueryType schemaType)
@@ -152,15 +152,6 @@ public class FormDesignerController : ControllerBase
     {
         try
         {
-            // var ensure = _formDesignerService.EnsureFieldsSaved(
-            //     model.TableName,
-            //     model.FORM_FIELD_Master_ID == Guid.Empty ? null : model.FORM_FIELD_Master_ID,
-            //     schemaType);
-            // if (ensure == null)
-            // {
-            //     return NotFound();
-            // }
-
             if (model.SchemaType == TableSchemaQueryType.OnlyTable &&
                 (model.QUERY_COMPONENT != QueryComponentType.None ||
                  model.CAN_QUERY == true))

--- a/Areas/Form/Controllers/FormDesignerMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormDesignerMasterDetailController.cs
@@ -74,8 +74,28 @@ public class FormDesignerMasterDetailController : ControllerBase
         return Ok(model);
     }
     
+    // ────────── 欄位相關 ──────────
+
     /// <summary>
-    /// 取得資料表所有欄位設定(如果傳入空formMasterId，會創建一筆新的，如果有傳入，會取得舊的)
+    /// 依表名稱關鍵字搜尋 表 或 檢視表，並回傳列表。
+    /// </summary>
+    [HttpGet("tables/tableName")]
+    public IActionResult SearchTables(string? tableName, [FromQuery] TableSchemaQueryType schemaType)
+    {
+        try
+        {
+            var result = _formDesignerService.SearchTables(tableName, schemaType);
+            if (result.Count == 0) return NotFound();
+            return Ok(result);
+        }
+        catch (HttpStatusCodeException ex)
+        {
+            return StatusCode((int)ex.StatusCode, ex.Message);
+        }
+    }
+    
+    /// <summary>
+    /// 取得資料表所有欄位設定(tableName必須傳，如果傳入空formMasterId，會創建一筆新的，如果有傳入formMasterId，會取得舊的)
     /// </summary>
     [HttpGet("tables/{tableName}/fields")]
     public IActionResult GetFields(string tableName, Guid? formMasterId, [FromQuery] TableSchemaQueryType schemaType)
@@ -94,6 +114,249 @@ public class FormDesignerMasterDetailController : ControllerBase
         {
             return StatusCode((int)ex.StatusCode, ex.Message);
         }
+    }
+    
+    /// <summary>
+    /// 依欄位設定 ID 取得單一欄位設定
+    /// </summary>
+    /// <param name="fieldId">欄位設定唯一識別碼</param>
+    [HttpGet("fields/{fieldId}")]
+    public IActionResult GetField(Guid fieldId)
+    {
+        var field = _formDesignerService.GetFieldById(fieldId);
+        if (field == null) return NotFound();
+        return Ok(field);
+    }
+    
+    /// <summary>
+    /// 新增或更新單一欄位設定（ID 有值為更新，無值為新增）
+    /// </summary>
+    // [RequirePermission(ActionAuthorizeHelper.View)]
+    [HttpPost("fields")]
+    public IActionResult UpsertField([FromBody] FormFieldViewModel model)
+    {
+        try
+        {
+            if (model.SchemaType == TableSchemaQueryType.OnlyTable &&
+                (model.QUERY_COMPONENT != QueryComponentType.None ||
+                 model.CAN_QUERY == true))
+                return Conflict("無法往主表寫入查詢條件");
+            
+            if (model.SchemaType == TableSchemaQueryType.OnlyTable &&
+                (model.QUERY_DEFAULT_VALUE != null ||
+                 model.CAN_QUERY == true))
+                return Conflict("無法往主表寫入查詢預設值");
+            
+            if (model.SchemaType == TableSchemaQueryType.OnlyView &&
+                (model.CAN_QUERY == false && model.QUERY_COMPONENT != QueryComponentType.None))
+                return Conflict("無法更改未開放查詢條件的查詢元件");
+            
+            if (model.ID != Guid.Empty &&
+                _formDesignerService.HasValidationRules(model.ID) &&
+                _formDesignerService.GetControlTypeByFieldId(model.ID) != model.CONTROL_TYPE)
+                return Conflict("已有驗證規則，無法變更控制元件類型");
+
+            var master = new FORM_FIELD_Master { ID = model.FORM_FIELD_Master_ID };
+            var formMasterId = _formDesignerService.GetOrCreateFormMasterId(master);
+
+            _formDesignerService.UpsertField(model, formMasterId);
+            var fields = _formDesignerService.GetFieldsByTableName(model.TableName, formMasterId, model.SchemaType);
+            fields.ID = formMasterId;
+            fields.SchemaQueryType = model.SchemaType;
+            return Ok(fields);
+        }
+        catch (HttpStatusCodeException ex)
+        {
+            return StatusCode((int)ex.StatusCode, ex.Message);
+        }
+    }
+    
+    /// <summary>
+    /// 批次設定所有欄位為可編輯/不可編輯
+    /// </summary>
+    [HttpPost("tables/{tableName}/fields/batch-editable")]
+    public IActionResult BatchSetEditable(
+        [FromQuery] Guid formMasterId,
+        string tableName,
+        [FromQuery] bool isEditable,
+        [FromQuery] TableSchemaQueryType schemaType)
+    {
+        if (schemaType != TableSchemaQueryType.OnlyTable)
+            return BadRequest("僅支援主檔欄位清單的批次設定。");
+
+        _formDesignerService.SetAllEditable(formMasterId, tableName, isEditable);
+        var fields = _formDesignerService.GetFieldsByTableName(tableName, formMasterId, schemaType);
+        fields.ID = formMasterId;
+        fields.SchemaQueryType = schemaType;
+        return Ok(fields);
+    }
+    
+    /// <summary>
+    /// 批次設定所有欄位為必填/非必填
+    /// </summary>
+    [HttpPost("tables/{tableName}/fields/batch-required")]
+    public IActionResult BatchSetRequired(
+        [FromQuery] Guid formMasterId,
+        string tableName,
+        [FromQuery] bool isRequired,
+        [FromQuery] TableSchemaQueryType schemaType)
+    {
+        if (schemaType != TableSchemaQueryType.OnlyTable)
+            return BadRequest("僅支援主檔欄位清單的批次設定。");
+
+        _formDesignerService.SetAllRequired(formMasterId, tableName, isRequired);
+        var fields = _formDesignerService.GetFieldsByTableName(tableName, formMasterId, schemaType);
+        fields.ID = formMasterId;
+        fields.SchemaQueryType = schemaType;
+        return Ok(fields);
+    }
+    
+    // ────────── 欄位驗證規則 ──────────
+
+    /// <summary>
+    /// 取得欄位驗證規則與驗證類型選項
+    /// </summary>
+    [HttpGet("fields/{fieldId:guid}/rules")]
+    public IActionResult GetValidationRules(Guid fieldId)
+    {
+        if (fieldId == Guid.Empty)
+            return BadRequest("請先設定控制元件後再新增驗證條件。");
+
+        // var options = GetValidationTypeOptions(fieldId);
+        var rules = _formDesignerService.GetValidationRulesByFieldId(fieldId);
+        return Ok(new { rules });   
+    }
+    
+    /// <summary>
+    /// 新增一筆空的驗證規則並回傳全部規則
+    /// </summary>
+    [HttpPost("fields/{fieldId:guid}/rules")]
+    public IActionResult AddEmptyValidationRule(Guid fieldId)
+    {
+        // var options = GetValidationTypeOptions(fieldId);
+        var rule = _formDesignerService.CreateEmptyValidationRule(fieldId);
+        _formDesignerService.InsertValidationRule(rule);
+        var rules = _formDesignerService.GetValidationRulesByFieldId(fieldId);
+        return Ok(new { rules });
+    }
+    
+    /// <summary>
+    /// 更新單一驗證規則
+    /// </summary>
+    [HttpPut("rules/{id:guid}")]
+    public IActionResult UpdateValidationRule([FromBody] FormFieldValidationRuleDto rule)
+    {
+        _formDesignerService.SaveValidationRule(rule);
+        return Ok();
+    }
+
+    /// <summary>
+    /// 刪除驗證規則
+    /// </summary>
+    [HttpDelete("rules/{id:guid}")]
+    public IActionResult DeleteValidationRule(Guid id, [FromQuery] Guid fieldConfigId)
+    {
+        _formDesignerService.DeleteValidationRule(id);
+        // var options = GetValidationTypeOptions(fieldConfigId);
+        var rules = _formDesignerService.GetValidationRulesByFieldId(fieldConfigId);
+        return Ok(new { rules });
+    }
+    
+    // ────────── Dropdown ──────────
+
+    /// <summary>
+    /// 取得下拉選單設定（不存在則自動建立）
+    /// </summary>
+    [HttpGet("fields/{fieldId:guid}/dropdown")]
+    public IActionResult GetDropdownSetting(Guid fieldId)
+    {
+        var field = _formDesignerService.GetFieldById(fieldId);
+        if (field == null)
+        {
+            return BadRequest("查無此設定檔，請確認ID是否正確。");
+        }
+        if (field.SchemaType != TableSchemaQueryType.OnlyView)
+        {
+            return BadRequest("查詢條件僅支援View表。");
+        }
+        _formDesignerService.EnsureDropdownCreated(fieldId);
+        var setting = _formDesignerService.GetDropdownSetting(fieldId);
+        return Ok(setting);
+    }
+
+    /// <summary>
+    /// 設定下拉選單資料來源模式（SQL/設定檔）
+    /// </summary>
+    [HttpPut("dropdowns/{dropdownId:guid}/mode")]
+    public IActionResult SetDropdownMode(Guid dropdownId, [FromQuery] bool isUseSql)
+    {
+        _formDesignerService.SetDropdownMode(dropdownId, isUseSql);
+        return Ok();
+    }
+
+    /// <summary>
+    /// 儲存下拉選單 SQL 查詢
+    /// </summary>
+    [HttpPut("dropdowns/{dropdownId:guid}/sql")]
+    public IActionResult SaveDropdownSql(Guid dropdownId, [FromBody] string sql)
+    {
+        _formDesignerService.SaveDropdownSql(dropdownId, sql);
+        return Ok();
+    }
+
+    /// <summary>
+    /// 驗證下拉 SQL 語法
+    /// </summary>
+    [HttpPost("dropdowns/validate-sql")]
+    public IActionResult ValidateDropdownSql([FromBody] string sql)
+    {
+        var res = _formDesignerService.ValidateDropdownSql(sql);
+        return Ok(res);
+    }
+
+    /// <summary>
+    /// 匯入下拉選單選項（由 SQL 查詢）
+    /// </summary>
+    [HttpPost("dropdowns/{dropdownId:guid}/import-options")]
+    public IActionResult ImportDropdownOptions(Guid dropdownId, [FromBody] ImportOptionDto dto)
+    {
+        var res = _formDesignerService.ImportDropdownOptionsFromSql(dto.Sql, dropdownId);
+        if (!res.Success) return BadRequest(res.Message);
+
+        var options = _formDesignerService.GetDropdownOptions(dropdownId);
+        return Ok(options);
+    }
+
+    /// <summary>
+    /// 建立一筆空白下拉選項
+    /// </summary>
+    [HttpPost("dropdowns/{dropdownId:guid}/options")]
+    public IActionResult CreateDropdownOption(Guid dropdownId)
+    {
+        _formDesignerService.SaveDropdownOption(null, dropdownId, "", "");
+        var options = _formDesignerService.GetDropdownOptions(dropdownId);
+        return Ok(options);
+    }
+
+    /// <summary>
+    /// 儲存單筆下拉選項（新增/更新）
+    /// </summary>
+    [HttpPut("dropdowns/{dropdownId:guid}/options")]
+    public IActionResult SaveDropdownOption(Guid dropdownId, [FromBody] SaveOptionDto dto)
+    {
+        _formDesignerService.SaveDropdownOption(dto.Id, dropdownId, dto.OptionText, dto.OptionValue);
+        return Ok();
+    }
+
+    /// <summary>
+    /// 刪除下拉選項
+    /// </summary>
+    [HttpDelete("dropdowns/options/{optionId:guid}")]
+    public IActionResult DeleteDropdownOption(Guid optionId, [FromQuery] Guid dropdownId)
+    {
+        _formDesignerService.DeleteDropdownOption(optionId);
+        var options = _formDesignerService.GetDropdownOptions(dropdownId);
+        return Ok(options);
     }
     
     /// <summary>

--- a/Areas/Form/Controllers/FormDesignerMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormDesignerMasterDetailController.cs
@@ -1,11 +1,8 @@
-using ClassLibrary;
+using System;
 using DcMateH5Api.Areas.Form.Interfaces;
-using DcMateH5Api.Areas.Form.Models;
 using DcMateH5Api.Areas.Form.ViewModels;
-using DcMateH5Api.Areas.Security.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using DcMateH5Api.Helper;
-using System.Threading;
 
 namespace DcMateH5Api.Areas.Form.Controllers;
 
@@ -21,5 +18,31 @@ public class FormDesignerMasterDetailController : ControllerBase
     public FormDesignerMasterDetailController(IFormDesignerService formDesignerService)
     {
         _formDesignerService = formDesignerService;
+    }
+
+    /// <summary>
+    /// 儲存 Master/Detail 表單主檔資訊
+    /// </summary>
+    [HttpPost("headers")]
+    public IActionResult SaveMasterDetailFormHeader([FromBody] MasterDetailFormHeaderViewModel model)
+    {
+        if (model.MASTER_TABLE_ID == Guid.Empty ||
+            model.DETAIL_TABLE_ID == Guid.Empty ||
+            model.VIEW_TABLE_ID == Guid.Empty)
+        {
+            return BadRequest("MASTER_TABLE_ID / DETAIL_TABLE_ID / VIEW_TABLE_ID 不可為空");
+        }
+
+        if (_formDesignerService.CheckMasterDetailFormMasterExists(
+                model.MASTER_TABLE_ID,
+                model.DETAIL_TABLE_ID,
+                model.VIEW_TABLE_ID,
+                model.ID))
+        {
+            return Conflict("相同的 Master/Detail/View 組合已存在");
+        }
+
+        var id = _formDesignerService.SaveMasterDetailFormHeader(model);
+        return Ok(new { id });
     }
 }

--- a/Areas/Form/Controllers/FormDesignerMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormDesignerMasterDetailController.cs
@@ -1,5 +1,7 @@
 using System;
+using ClassLibrary;
 using DcMateH5Api.Areas.Form.Interfaces;
+using DcMateH5Api.Areas.Form.Models;
 using DcMateH5Api.Areas.Form.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using DcMateH5Api.Helper;
@@ -8,18 +10,92 @@ namespace DcMateH5Api.Areas.Form.Controllers;
 
 [Area("Form")]
 [ApiController]
-[ApiExplorerSettings(GroupName = SwaggerGroups.Form)]
+[ApiExplorerSettings(GroupName = SwaggerGroups.FormWithMasterDetail)]
 [Route("[area]/[controller]")]
 [Produces("application/json")]
 public class FormDesignerMasterDetailController : ControllerBase
 {
     private readonly IFormDesignerService _formDesignerService;
-
+    private readonly FormFunctionType _funcType = FormFunctionType.MasterDetail;
+    
     public FormDesignerMasterDetailController(IFormDesignerService formDesignerService)
     {
         _formDesignerService = formDesignerService;
     }
 
+    // ────────── Form Designer 列表 ──────────
+    /// <summary>
+    /// 取得表單主檔 (FORM_FIELD_Master) 清單
+    /// </summary>
+    /// <param name="q">關鍵字 (模糊搜尋 FORM_NAME)</param>
+    /// <param name="ct">CancellationToken</param>
+    /// <returns>表單主檔清單</returns>
+    [HttpGet]
+    public async Task<ActionResult<List<FORM_FIELD_Master>>> GetFormMasters(
+        [FromQuery] string? q,
+        CancellationToken ct)
+    {
+        var masters = await _formDesignerService.GetFormMasters(_funcType, q, ct);
+
+        return Ok(masters.ToList());
+    }
+    
+    /// <summary>
+    /// 更新主檔 or 明細 or 檢視表 名稱
+    /// </summary>
+    [HttpPut("form-name")]
+    public async Task<IActionResult> UpdateFormName([FromBody] UpdateFormNameViewModel model, CancellationToken ct)
+    {
+        await _formDesignerService.UpdateFormName(model.ID, model.FORM_NAME, ct);
+        return Ok();
+    }
+    
+    /// <summary>
+    /// 刪除指定的主檔 or 明細 or 檢視表資料
+    /// </summary>
+    /// <param name="id">FORM_FIELD_Master 的唯一識別編號</param>
+    /// <returns>NoContent 回應</returns>
+    [HttpDelete("{id}")]
+    public IActionResult Delete(Guid id)
+    {
+        _formDesignerService.DeleteFormMaster(id);
+        return NoContent();
+    }
+    
+    // ────────── Form Designer 入口 ──────────
+    /// <summary>
+    /// 取得指定的 主檔 and 明細 and 檢視表 主畫面資料(請傳入父節點 masterId)
+    /// </summary>
+    // [RequirePermission(ActionAuthorizeHelper.View)]
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetDesigner(Guid id, CancellationToken ct)
+    {
+        var model = await _formDesignerService.GetFormDesignerIndexViewModel(_funcType, id, ct);
+        return Ok(model);
+    }
+    
+    /// <summary>
+    /// 取得資料表所有欄位設定(如果傳入空formMasterId，會創建一筆新的，如果有傳入，會取得舊的)
+    /// </summary>
+    [HttpGet("tables/{tableName}/fields")]
+    public IActionResult GetFields(string tableName, Guid? formMasterId, [FromQuery] TableSchemaQueryType schemaType)
+    {
+        try
+        {
+            var result = _formDesignerService.EnsureFieldsSaved(tableName, formMasterId, schemaType);
+
+            if (result == null)
+            {
+                return NotFound();
+            }
+            return Ok(result);
+        }
+        catch (HttpStatusCodeException ex)
+        {
+            return StatusCode((int)ex.StatusCode, ex.Message);
+        }
+    }
+    
     /// <summary>
     /// 儲存 Master/Detail 表單主檔資訊
     /// </summary>

--- a/Areas/Form/Controllers/FormMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormMasterDetailController.cs
@@ -1,0 +1,76 @@
+// using DcMateH5Api.Areas.Form.Models;
+// using DcMateH5Api.Areas.Form.Interfaces;
+// using DcMateH5Api.Areas.Form.ViewModels;
+// using Microsoft.AspNetCore.Mvc;
+// using DcMateH5Api.Helper;
+//
+// namespace DcMateH5Api.Areas.Form.Controllers;
+//
+// /// <summary>
+// /// 主明細變更 API
+// /// </summary>
+// [Area("Form")]
+// [ApiController]
+// [ApiExplorerSettings(GroupName = SwaggerGroups.FormWithMasterDetail)]
+// [Route("[area]/[controller]")]
+// [Produces("application/json")]
+// public class FormMasterDetailController : ControllerBase
+// {
+//     private readonly IFormService _formService;
+//
+//     public FormMasterDetailController(IFormService formService)
+//     {
+//         _formService = formService;
+//     }
+//     
+//     /// <summary>
+//     /// 範例輸入：
+//     /// <code>
+//     /// [
+//     ///   {
+//     ///     "column": "STATUS_CALCD_TIME",
+//     ///     "queryConditionType": 3,
+//     ///     "value": "2024-12-31",
+//     ///     "value2": "2025-01-02",
+//     ///     "dataType": "datetime"
+//     ///   }
+//     /// ]
+//     /// </code>
+//     /// </summary>
+//     /// <param name="conditions">查詢條件</param>
+//     /// <returns>查詢結果</returns>
+//     [HttpPost("search")]
+//     public IActionResult GetForms([FromBody] List<FormQueryCondition>? conditions)
+//     {
+//         var vm = _formService.GetFormList(conditions);
+//         return Ok(vm);
+//     }
+//     
+//     /// <summary>
+//     /// 取得編輯/檢視/新增資料表單
+//     /// </summary>
+//     /// <param name="formId">FORM_FIELD_Master.ID</param>
+//     /// <param name="pk">資料主鍵，不傳為新增</param>
+//     /// <returns>回傳填寫表單的畫面</returns>
+//     [HttpPost("{formId}")]
+//     public IActionResult GetForm(Guid formId, string? pk)
+//     {
+//         var vm = pk != null
+//             ? _formService.GetFormSubmission(formId, pk)
+//             : _formService.GetFormSubmission(formId);
+//         return Ok(vm);
+//     }
+//
+//     /// <summary>
+//     /// 提交表單
+//     /// </summary>
+//     /// <param name="input"></param>
+//     /// <returns></returns>
+//     [HttpPost]
+//     public IActionResult SubmitForm([FromBody] FormSubmissionInputModel input)
+//     {
+//         _formService.SubmitForm(input);
+//         return NoContent();
+//     }
+//
+// }

--- a/Areas/Form/Interfaces/IFormDesignerService.cs
+++ b/Areas/Form/Interfaces/IFormDesignerService.cs
@@ -100,6 +100,8 @@ public interface IFormDesignerService
     ValidateSqlResultViewModel ImportDropdownOptionsFromSql(string sql, Guid dropdownId);
     Guid SaveFormHeader( FormHeaderViewModel model );
 
+    Guid SaveMasterDetailFormHeader(MasterDetailFormHeaderViewModel model);
+
     /// <summary>
     /// 檢查表格名稱與 View 名稱的組合是否已存在於 FORM_FIELD_Master
     /// </summary>
@@ -108,4 +110,6 @@ public interface IFormDesignerService
     /// <param name="excludeId">編輯時排除自身 ID</param>
     /// <returns>若存在相同組合則回傳 true</returns>
     bool CheckFormMasterExists(Guid baseTableId, Guid viewTableId, Guid? excludeId = null);
+
+    bool CheckMasterDetailFormMasterExists(Guid masterTableId, Guid detailTableId, Guid viewTableId, Guid? excludeId = null);
 }

--- a/Areas/Form/Interfaces/IFormDesignerService.cs
+++ b/Areas/Form/Interfaces/IFormDesignerService.cs
@@ -7,13 +7,13 @@ namespace DcMateH5Api.Areas.Form.Interfaces;
 
 public interface IFormDesignerService
 {
-    Task<List<FORM_FIELD_Master>> GetFormMasters(TableSchemaQueryType schemaType, CancellationToken ct);
+    Task<List<FORM_FIELD_Master>> GetFormMasters(FormFunctionType functionType, string? q, CancellationToken ct);
 
     Task UpdateFormMaster(FORM_FIELD_Master model, CancellationToken ct);
     
     void DeleteFormMaster(Guid id);
     
-    Task<FormDesignerIndexViewModel> GetFormDesignerIndexViewModel(Guid? id, CancellationToken ct);
+    Task<FormDesignerIndexViewModel> GetFormDesignerIndexViewModel(FormFunctionType functionType, Guid? id, CancellationToken ct);
     
     /// <summary>
     /// 依名稱關鍵字查詢資料表或檢視表名稱清單。

--- a/Areas/Form/Models/FORM_FIELD_Master.cs
+++ b/Areas/Form/Models/FORM_FIELD_Master.cs
@@ -16,26 +16,32 @@ public class FORM_FIELD_Master
     [Column("FORM_NAME")]
     public string FORM_NAME { get; set; }  
     
+    
+    
     [Column("BASE_TABLE_NAME")]
-    public string BASE_TABLE_NAME { get; set; }  
+    public string? BASE_TABLE_NAME { get; set; }  
+    
+    [Column("DETAIL_TABLE_NAME")]
+    public string? DETAIL_TABLE_NAME { get; set; }
     
     [Column("VIEW_TABLE_NAME")]
-    public string VIEW_TABLE_NAME { get; set; }
+    public string? VIEW_TABLE_NAME { get; set; }
+    
+    
     
     [Column("BASE_TABLE_ID")]
     public Guid? BASE_TABLE_ID { get; set; }
     
-    [Column("VIEW_TABLE_ID")]
-    public Guid? VIEW_TABLE_ID { get; set; }
-
-    [Column("DETAIL_TABLE_NAME")]
-    public string? DETAIL_TABLE_NAME { get; set; }
-
     [Column("DETAIL_TABLE_ID")]
     public Guid? DETAIL_TABLE_ID { get; set; }
+    
+    [Column("VIEW_TABLE_ID")]
+    public Guid? VIEW_TABLE_ID { get; set; }
+    
+    
 
     [Column("IS_MASTER_DETAIL")]
-    public bool IS_MASTER_DETAIL { get; set; }
+    public bool? IS_MASTER_DETAIL { get; set; }
     
     [Column("STATUS")]
     public int STATUS { get; set; }  

--- a/Areas/Form/Models/FORM_FIELD_Master.cs
+++ b/Areas/Form/Models/FORM_FIELD_Master.cs
@@ -41,7 +41,7 @@ public class FORM_FIELD_Master
     
 
     [Column("IS_MASTER_DETAIL")]
-    public bool? IS_MASTER_DETAIL { get; set; }
+    public FormFunctionType? IS_MASTER_DETAIL { get; set; }
     
     [Column("STATUS")]
     public int STATUS { get; set; }  

--- a/Areas/Form/Models/FORM_FIELD_Master.cs
+++ b/Areas/Form/Models/FORM_FIELD_Master.cs
@@ -27,6 +27,15 @@ public class FORM_FIELD_Master
     
     [Column("VIEW_TABLE_ID")]
     public Guid? VIEW_TABLE_ID { get; set; }
+
+    [Column("DETAIL_TABLE_NAME")]
+    public string? DETAIL_TABLE_NAME { get; set; }
+
+    [Column("DETAIL_TABLE_ID")]
+    public Guid? DETAIL_TABLE_ID { get; set; }
+
+    [Column("IS_MASTER_DETAIL")]
+    public bool IS_MASTER_DETAIL { get; set; }
     
     [Column("STATUS")]
     public int STATUS { get; set; }  

--- a/Areas/Form/Models/FormQueryCondition.cs
+++ b/Areas/Form/Models/FormQueryCondition.cs
@@ -2,6 +2,13 @@ using ClassLibrary;
 
 namespace DcMateH5Api.Areas.Form.Models;
 
+public sealed record FormSearchRequest(
+    Guid FormMasterId,
+    int Page = 1,
+    int PageSize = 20,
+    List<FormQueryCondition>? Conditions = null
+);
+
 /// <summary>
 /// 描述查詢條件的資料模型。
 /// </summary>

--- a/Areas/Form/ViewModels/FormDesignerIndexViewModel.cs
+++ b/Areas/Form/ViewModels/FormDesignerIndexViewModel.cs
@@ -10,18 +10,18 @@ public class FormDesignerIndexViewModel
     public FORM_FIELD_Master FormHeader { get; set; } = new();
 
     /// <summary>
-    /// 主表欄位設定清單
+    /// 主檔欄位設定清單
     /// </summary>
     public FormFieldListViewModel BaseFields { get; set; } = new();
+    
+    /// <summary>
+    /// 主檔欄位設定清單
+    /// </summary>
+    public FormFieldListViewModel DetailFields { get; set; } = new();
 
     /// <summary>
-    /// 檢視(View)欄位設定清單
+    /// 檢視表欄位設定清單
     /// </summary>
     public FormFieldListViewModel ViewFields { get; set; } = new();
-
-    /// <summary>
-    /// 右側欄位設定編輯區所需的資料
-    /// </summary>
-    public FormFieldViewModel FieldSetting { get; set; } = new();
 }
 

--- a/Areas/Form/ViewModels/MasterDetailFormHeaderViewModel.cs
+++ b/Areas/Form/ViewModels/MasterDetailFormHeaderViewModel.cs
@@ -1,0 +1,32 @@
+namespace DcMateH5Api.Areas.Form.ViewModels;
+
+/// <summary>
+/// 儲存 Master/Detail 表單主檔資訊使用的 ViewModel。
+/// </summary>
+public class MasterDetailFormHeaderViewModel
+{
+    /// <summary>
+    /// FORM_FIELD_Master 主檔 ID
+    /// </summary>
+    public Guid ID { get; set; }
+
+    /// <summary>
+    /// 表單名稱
+    /// </summary>
+    public string FORM_NAME { get; set; }
+
+    /// <summary>
+    /// Master 表單的 FORM_FIELD_Master ID
+    /// </summary>
+    public Guid MASTER_TABLE_ID { get; set; }
+
+    /// <summary>
+    /// Detail 表單的 FORM_FIELD_Master ID
+    /// </summary>
+    public Guid DETAIL_TABLE_ID { get; set; }
+
+    /// <summary>
+    /// Master+Detail View 的 FORM_FIELD_Master ID
+    /// </summary>
+    public Guid VIEW_TABLE_ID { get; set; }
+}

--- a/DcMateClassLibrary/Enum/FormFunctionType.cs
+++ b/DcMateClassLibrary/Enum/FormFunctionType.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ClassLibrary;
+
+public enum FormFunctionType
+{
+    [Display(Name = "主檔維護", Description = "主檔維護")]
+    NotMasterDetail = 0,   
+    
+    [Display(Name = "主明細維護", Description = "主明細維護")]
+    MasterDetail = 1,   
+}

--- a/DcMateClassLibrary/Enum/TableSchemaQueryType.cs
+++ b/DcMateClassLibrary/Enum/TableSchemaQueryType.cs
@@ -7,9 +7,12 @@ public enum TableSchemaQueryType
     [Display(Name = "主表", Description = "主要更改的目標資料表(主檔)")]
     OnlyTable = 0,   
     
+    [Display(Name = "明細表", Description = "主要更改的明細資料表(明細檔)")]
+    OnlyDetail = 1,   
+    
     [Display(Name = "檢視表", Description = "呈現、搜尋特定條件的資料表(檢視表)")]
-    OnlyView = 1,   
+    OnlyView = 2,   
     
     [Display(Name = "主表與檢視表", Description = "兩種一次取出(前述兩者為共用資料表)")]
-    All = 2        
+    All = 3      
 }

--- a/DcMateClassLibrary/Helper/SwaggerGroups.cs
+++ b/DcMateClassLibrary/Helper/SwaggerGroups.cs
@@ -12,6 +12,7 @@ public static class SwaggerGroups
     public const string Permission = nameof(Permission);
     public const string Enum = nameof(Enum);
     public const string Form = nameof(Form);
+    public const string FormWithMasterDetail = nameof(FormWithMasterDetail);
     public const string Log = nameof(Log);
     
     public static readonly Dictionary<string, string> DisplayNames = new()
@@ -21,6 +22,7 @@ public static class SwaggerGroups
         { Permission, "群組、功能、權限設定" },
         { Enum, "列舉" },
         { Form, "主檔維護" },
+        { FormWithMasterDetail, "主明細維護" },
         { Log, "系統紀錄" }
     };
 }

--- a/DcMateH5Api.Tests/ApiControllerTest/FormDesignerControllerTests.cs
+++ b/DcMateH5Api.Tests/ApiControllerTest/FormDesignerControllerTests.cs
@@ -106,17 +106,6 @@ public class FormDesignerControllerTests
     }
 
     [Fact]
-    public void SaveMasterDetailFormHeader_MissingIds_ReturnsBadRequest()
-    {
-        var controller = CreateController();
-        var vm = new MasterDetailFormHeaderViewModel();
-
-        var result = controller.SaveMasterDetailFormHeader(vm);
-
-        Assert.IsType<BadRequestObjectResult>(result);
-    }
-
-    [Fact]
     public void GetFields_MissingSystemColumns_ReturnsBadRequest()
     {
         var controller = CreateController();

--- a/DcMateH5Api.Tests/ApiControllerTest/FormDesignerControllerTests.cs
+++ b/DcMateH5Api.Tests/ApiControllerTest/FormDesignerControllerTests.cs
@@ -106,6 +106,17 @@ public class FormDesignerControllerTests
     }
 
     [Fact]
+    public void SaveMasterDetailFormHeader_MissingIds_ReturnsBadRequest()
+    {
+        var controller = CreateController();
+        var vm = new MasterDetailFormHeaderViewModel();
+
+        var result = controller.SaveMasterDetailFormHeader(vm);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
     public void GetFields_MissingSystemColumns_ReturnsBadRequest()
     {
         var controller = CreateController();

--- a/DcMateH5Api.Tests/ApiControllerTest/FormDesignerMasterDetailControllerTests.cs
+++ b/DcMateH5Api.Tests/ApiControllerTest/FormDesignerMasterDetailControllerTests.cs
@@ -1,0 +1,26 @@
+using DcMateH5Api.Areas.Form.Controllers;
+using DcMateH5Api.Areas.Form.Interfaces;
+using DcMateH5Api.Areas.Form.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace DcMateH5Api.Tests.ApiControllerTest;
+
+public class FormDesignerMasterDetailControllerTests
+{
+    private readonly Mock<IFormDesignerService> _serviceMock = new();
+
+    private FormDesignerMasterDetailController CreateController()
+        => new FormDesignerMasterDetailController(_serviceMock.Object);
+
+    [Fact]
+    public void SaveMasterDetailFormHeader_MissingIds_ReturnsBadRequest()
+    {
+        var controller = CreateController();
+        var vm = new MasterDetailFormHeaderViewModel();
+
+        var result = controller.SaveMasterDetailFormHeader(vm);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -136,6 +136,7 @@ builder.Services.AddHealthChecks()
 var swaggerGroups = new[]
 {
     SwaggerGroups.Form,
+    SwaggerGroups.FormWithMasterDetail,
     SwaggerGroups.Permission,
     SwaggerGroups.Security,
     SwaggerGroups.Enum,


### PR DESCRIPTION
## Summary
- extend FORM_FIELD_Master with detail table metadata and master-detail flag
- add API endpoint SaveMasterDetailFormHeader for linking master/detail/view tables
- cover controller with unit test for required IDs

## Testing
- `~/.dotnet/dotnet test` *(fails: Microsoft.Build.Exceptions.InternalLoggerException: Specified argument was out of the range of valid values)*

------
https://chatgpt.com/codex/tasks/task_e_68b92b5605388320b316ef5416354a5f