### PR TITLE
feat: add pagination to form search

### DIFF
--- a/Areas/Form/Controllers/FormController.cs
+++ b/Areas/Form/Controllers/FormController.cs
@@ -36,12 +36,12 @@ public class FormController : ControllerBase
     /// ]
     /// </code>
     /// </summary>
-    /// <param name="conditions">查詢條件</param>
+    /// <param name="request">查詢條件與分頁設定</param>
     /// <returns>查詢結果</returns>
     [HttpPost("search")]
-    public IActionResult GetForms([FromBody] FormSearchRequest conditions)
+    public IActionResult GetForms([FromBody] FormSearchRequest? request)
     {
-        var vm = _formService.GetFormList(conditions);
+        var vm = _formService.GetFormList(request);
         return Ok(vm);
     }
     

--- a/Areas/Form/Interfaces/FormLogic/IFormDataService.cs
+++ b/Areas/Form/Interfaces/FormLogic/IFormDataService.cs
@@ -10,8 +10,14 @@ public interface IFormDataService
     /// </summary>
     /// <param name="tableName">目標資料表或檢視表名稱。</param>
     /// <param name="conditions">查詢條件集合。</param>
+    /// <param name="page">頁碼（從 1 開始）。</param>
+    /// <param name="pageSize">每頁筆數。</param>
     /// <returns>符合條件的資料列。</returns>
-    List<IDictionary<string, object?>> GetRows(string tableName, IEnumerable<FormQueryCondition>? conditions = null);
+    List<IDictionary<string, object?>> GetRows(
+        string tableName,
+        IEnumerable<FormQueryCondition>? conditions = null,
+        int? page = null,
+        int? pageSize = null);
 
     Dictionary<string, string> LoadColumnTypes(string tableName);
 }

--- a/Areas/Form/Interfaces/IFormService.cs
+++ b/Areas/Form/Interfaces/IFormService.cs
@@ -7,11 +7,11 @@ namespace DcMateH5Api.Areas.Form.Interfaces;
 public interface IFormService
 {
     /// <summary>
-    /// 取得所有表單的資料列表。
+    /// 取得所有表單的資料列表，支援分頁。
     /// </summary>
-    /// <param name="conditions">查詢條件集合。</param>
+    /// <param name="request">查詢條件與分頁設定。</param>
     /// <returns>每個表單對應的欄位與資料列集合。</returns>
-    List<FormListDataViewModel> GetFormList(IEnumerable<FormQueryCondition>? conditions = null);
+    List<FormListDataViewModel> GetFormList(FormSearchRequest? request = null);
     
     /// <summary>
     /// 取得 單一

--- a/DcMateH5Api.Tests/ApiControllerTest/FormControllerTests.cs
+++ b/DcMateH5Api.Tests/ApiControllerTest/FormControllerTests.cs
@@ -37,6 +37,19 @@ public class FormControllerTests
     }
 
     [Fact]
+    public void GetForms_WithRequest_ReturnsOk()
+    {
+        var request = new FormSearchRequest(Guid.NewGuid());
+        var vm = new List<FormListDataViewModel>();
+        _serviceMock.Setup(s => s.GetFormList(request)).Returns(vm);
+
+        var result = _controller.GetForms(request) as OkObjectResult;
+
+        Assert.NotNull(result);
+        Assert.Equal(vm, result.Value);
+    }
+
+    [Fact]
     public void GetForm_WithRowId_CallsServiceWithId()
     {
         var formId = Guid.NewGuid();


### PR DESCRIPTION
## Summary
- add pagination parameters to form search API and service
- support paging in data service via SQL OFFSET/FETCH
- cover controller behavior with pagination unit test

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 10.0)*

------
https://chatgpt.com/codex/tasks/task_e_68be455b23388320b3b7cd194a07a637