### PR TITLE
feat: add master-detail form controller and service

### DIFF
--- a/Areas/Form/Controllers/FormController.cs
+++ b/Areas/Form/Controllers/FormController.cs
@@ -41,6 +41,15 @@ public class FormController : ControllerBase
     [HttpPost("search")]
     public IActionResult GetForms([FromBody] FormSearchRequest? request)
     {
+        if (request == null)
+        {
+            return BadRequest(new
+            {
+                Error = "Request body is null",
+                Hint  = "請確認傳入的 JSON 是否正確，至少需要提供查詢條件或分頁參數"
+            });
+        }
+        
         var vm = _formService.GetFormList(request);
         return Ok(vm);
     }

--- a/Areas/Form/Controllers/FormMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormMasterDetailController.cs
@@ -1,76 +1,58 @@
-// using DcMateH5Api.Areas.Form.Models;
-// using DcMateH5Api.Areas.Form.Interfaces;
-// using DcMateH5Api.Areas.Form.ViewModels;
-// using Microsoft.AspNetCore.Mvc;
-// using DcMateH5Api.Helper;
-//
-// namespace DcMateH5Api.Areas.Form.Controllers;
-//
-// /// <summary>
-// /// 主明細變更 API
-// /// </summary>
-// [Area("Form")]
-// [ApiController]
-// [ApiExplorerSettings(GroupName = SwaggerGroups.FormWithMasterDetail)]
-// [Route("[area]/[controller]")]
-// [Produces("application/json")]
-// public class FormMasterDetailController : ControllerBase
-// {
-//     private readonly IFormService _formService;
-//
-//     public FormMasterDetailController(IFormService formService)
-//     {
-//         _formService = formService;
-//     }
-//     
-//     /// <summary>
-//     /// 範例輸入：
-//     /// <code>
-//     /// [
-//     ///   {
-//     ///     "column": "STATUS_CALCD_TIME",
-//     ///     "queryConditionType": 3,
-//     ///     "value": "2024-12-31",
-//     ///     "value2": "2025-01-02",
-//     ///     "dataType": "datetime"
-//     ///   }
-//     /// ]
-//     /// </code>
-//     /// </summary>
-//     /// <param name="conditions">查詢條件</param>
-//     /// <returns>查詢結果</returns>
-//     [HttpPost("search")]
-//     public IActionResult GetForms([FromBody] List<FormQueryCondition>? conditions)
-//     {
-//         var vm = _formService.GetFormList(conditions);
-//         return Ok(vm);
-//     }
-//     
-//     /// <summary>
-//     /// 取得編輯/檢視/新增資料表單
-//     /// </summary>
-//     /// <param name="formId">FORM_FIELD_Master.ID</param>
-//     /// <param name="pk">資料主鍵，不傳為新增</param>
-//     /// <returns>回傳填寫表單的畫面</returns>
-//     [HttpPost("{formId}")]
-//     public IActionResult GetForm(Guid formId, string? pk)
-//     {
-//         var vm = pk != null
-//             ? _formService.GetFormSubmission(formId, pk)
-//             : _formService.GetFormSubmission(formId);
-//         return Ok(vm);
-//     }
-//
-//     /// <summary>
-//     /// 提交表單
-//     /// </summary>
-//     /// <param name="input"></param>
-//     /// <returns></returns>
-//     [HttpPost]
-//     public IActionResult SubmitForm([FromBody] FormSubmissionInputModel input)
-//     {
-//         _formService.SubmitForm(input);
-//         return NoContent();
-//     }
-//
-// }
+using DcMateH5Api.Areas.Form.Interfaces;
+using DcMateH5Api.Areas.Form.Models;
+using DcMateH5Api.Areas.Form.ViewModels;
+using DcMateH5Api.Helper;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DcMateH5Api.Areas.Form.Controllers;
+
+/// <summary>
+/// 主明細表單維護 API。
+/// </summary>
+[Area("Form")]
+[ApiController]
+[ApiExplorerSettings(GroupName = SwaggerGroups.FormWithMasterDetail)]
+[Route("[area]/[controller]")]
+public class FormMasterDetailController : ControllerBase
+{
+    private readonly IFormMasterDetailService _service;
+
+    public FormMasterDetailController(IFormMasterDetailService service)
+    {
+        _service = service;
+    }
+
+    /// <summary>
+    /// 取得主明細表單的資料列表。
+    /// </summary>
+    /// <param name="request">查詢條件與分頁設定。</param>
+    [HttpPost("search")]
+    public IActionResult GetForms([FromBody] FormSearchRequest? request)
+    {
+        var vm = _service.GetFormList(request);
+        return Ok(vm);
+    }
+
+    /// <summary>
+    /// 取得主表與明細表的編輯/檢視/新增資料表單。
+    /// </summary>
+    /// <param name="formId">主明細表頭的 FORM_FIELD_Master.ID。</param>
+    /// <param name="pk">主表資料主鍵，不傳為新增。</param>
+    [HttpPost("{formId}")]
+    public IActionResult GetForm(Guid formId, string? pk)
+    {
+        var vm = _service.GetFormSubmission(formId, pk);
+        return Ok(vm);
+    }
+
+    /// <summary>
+    /// 提交主表與明細表資料。
+    /// </summary>
+    /// <param name="input">提交資料。</param>
+    [HttpPost]
+    public IActionResult SubmitForm([FromBody] FormMasterDetailSubmissionInputModel input)
+    {
+        _service.SubmitForm(input);
+        return NoContent();
+    }
+}

--- a/Areas/Form/Controllers/FormMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormMasterDetailController.cs
@@ -29,6 +29,14 @@ public class FormMasterDetailController : ControllerBase
     [HttpPost("search")]
     public IActionResult GetForms([FromBody] FormSearchRequest? request)
     {
+        if (request == null)
+        {
+            return BadRequest(new
+            {
+                Error = "Request body is null",
+                Hint  = "請確認傳入的 JSON 是否正確，至少需要提供查詢條件或分頁參數"
+            });
+        }
         var vm = _service.GetFormList(request);
         return Ok(vm);
     }

--- a/Areas/Form/Interfaces/FormLogic/IFormFieldMasterService.cs
+++ b/Areas/Form/Interfaces/FormLogic/IFormFieldMasterService.cs
@@ -9,7 +9,7 @@ public interface IFormFieldMasterService
 {
     FORM_FIELD_Master? GetFormFieldMaster(TableSchemaQueryType type);
 
-    FORM_FIELD_Master GetFormFieldMasterFromId(Guid id, SqlTransaction? tx = null );
+    FORM_FIELD_Master GetFormFieldMasterFromId(Guid? id, SqlTransaction? tx = null );
 
     List<(FORM_FIELD_Master Master, List<FormFieldConfigDto> FieldConfigs)> GetFormMetaAggregates(
         TableSchemaQueryType type);

--- a/Areas/Form/Interfaces/IFormMasterDetailService.cs
+++ b/Areas/Form/Interfaces/IFormMasterDetailService.cs
@@ -1,0 +1,31 @@
+using DcMateH5Api.Areas.Form.Models;
+using DcMateH5Api.Areas.Form.ViewModels;
+
+namespace DcMateH5Api.Areas.Form.Interfaces;
+
+/// <summary>
+/// 提供主明細表單的 CRUD 服務介面。
+/// </summary>
+public interface IFormMasterDetailService
+{
+    /// <summary>
+    /// 取得主明細表單的資料列表。
+    /// </summary>
+    /// <param name="request">查詢條件與分頁設定。</param>
+    /// <returns>表單資料列表。</returns>
+    List<FormListDataViewModel> GetFormList(FormSearchRequest? request = null);
+
+    /// <summary>
+    /// 取得主表與明細表的填寫畫面與資料。
+    /// </summary>
+    /// <param name="formMasterDetailId">主明細表單的 FORM_FIELD_Master.ID</param>
+    /// <param name="pk">主表資料主鍵，不傳為新增。</param>
+    /// <returns>主表與明細表的填寫資料。</returns>
+    FormMasterDetailSubmissionViewModel GetFormSubmission(Guid formMasterDetailId, string? pk = null);
+
+    /// <summary>
+    /// 新增或更新主表與明細表資料。
+    /// </summary>
+    /// <param name="input">主明細表單的提交資料。</param>
+    void SubmitForm(FormMasterDetailSubmissionInputModel input);
+}

--- a/Areas/Form/Interfaces/IFormService.cs
+++ b/Areas/Form/Interfaces/IFormService.cs
@@ -19,7 +19,7 @@ public interface IFormService
     /// <param name="id"></param>
     /// <param name="pk"></param>
     /// <returns></returns>
-    FormSubmissionViewModel GetFormSubmission(Guid id, string? pk = null);
+    FormSubmissionViewModel GetFormSubmission(Guid? id, string? pk = null);
 
     /// <summary>
     /// 儲存或更新表單資料

--- a/Areas/Form/Services/FormDesignerService.cs
+++ b/Areas/Form/Services/FormDesignerService.cs
@@ -232,9 +232,19 @@ public class FormDesignerService : IFormDesignerService
             return res.Value;
 
         var insertId = model.ID == Guid.Empty ? Guid.NewGuid() : model.ID;
+        static bool HasValue(string? s) => !string.IsNullOrWhiteSpace(s);
+        
         _con.Execute(@"
-        INSERT INTO FORM_FIELD_Master (ID, FORM_NAME, STATUS, SCHEMA_TYPE, BASE_TABLE_NAME, VIEW_TABLE_NAME, DETAIL_TABLE_NAME, DETAIL_TABLE_ID, IS_MASTER_DETAIL, IS_DELETE)
-        VALUES (@ID, @FORM_NAME, @STATUS, @SCHEMA_TYPE, @BASE_TABLE_NAME, @VIEW_TABLE_NAME, @DETAIL_TABLE_NAME, @DETAIL_TABLE_ID, @IS_MASTER_DETAIL)", new
+        INSERT INTO FORM_FIELD_Master
+    (ID, FORM_NAME, STATUS, SCHEMA_TYPE,
+     BASE_TABLE_NAME, VIEW_TABLE_NAME, DETAIL_TABLE_NAME,
+     BASE_TABLE_ID,  VIEW_TABLE_ID,  DETAIL_TABLE_ID,
+     IS_MASTER_DETAIL, IS_DELETE)
+    VALUES
+    (@ID, @FORM_NAME, @STATUS, @SCHEMA_TYPE,
+     @BASE_TABLE_NAME, @VIEW_TABLE_NAME, @DETAIL_TABLE_NAME,
+     @BASE_TABLE_ID,  @VIEW_TABLE_ID,  @DETAIL_TABLE_ID,
+     @IS_MASTER_DETAIL, 0);", new
         {
             ID = insertId,
             model.FORM_NAME,
@@ -243,7 +253,12 @@ public class FormDesignerService : IFormDesignerService
             model.BASE_TABLE_NAME,
             model.VIEW_TABLE_NAME,
             model.DETAIL_TABLE_NAME,
-            model.DETAIL_TABLE_ID
+
+            BASE_TABLE_ID   = HasValue(model.BASE_TABLE_NAME)   ? insertId : (Guid?)null,
+            VIEW_TABLE_ID   = HasValue(model.VIEW_TABLE_NAME)   ? insertId : (Guid?)null,
+            DETAIL_TABLE_ID = HasValue(model.DETAIL_TABLE_NAME) ? insertId : (Guid?)null,
+
+            model.IS_MASTER_DETAIL,
         });
 
         return insertId;

--- a/Areas/Form/Services/FormLogic/FormFieldMasterService.cs
+++ b/Areas/Form/Services/FormLogic/FormFieldMasterService.cs
@@ -23,7 +23,7 @@ public class FormFieldMasterService : IFormFieldMasterService
             new { TYPE = type.ToInt() });
     }
 
-    public FORM_FIELD_Master GetFormFieldMasterFromId(Guid id, SqlTransaction? tx = null)
+    public FORM_FIELD_Master GetFormFieldMasterFromId(Guid? id, SqlTransaction? tx = null)
     {
         return _con.QueryFirst<FORM_FIELD_Master>(
             "/**/SELECT * FROM FORM_FIELD_Master WHERE ID = @id",

--- a/Areas/Form/Services/FormMasterDetailService.cs
+++ b/Areas/Form/Services/FormMasterDetailService.cs
@@ -1,0 +1,153 @@
+using ClassLibrary;
+using Dapper;
+using DcMateH5Api.Areas.Form.Interfaces;
+using DcMateH5Api.Areas.Form.Interfaces.FormLogic;
+using DcMateH5Api.Areas.Form.Interfaces.Transaction;
+using DcMateH5Api.Areas.Form.Models;
+using DcMateH5Api.Areas.Form.ViewModels;
+using Microsoft.Data.SqlClient;
+
+namespace DcMateH5Api.Areas.Form.Services;
+
+/// <summary>
+/// 處理主表與明細表 CRUD 的服務。
+/// </summary>
+public class FormMasterDetailService : IFormMasterDetailService
+{
+    private readonly SqlConnection _con;
+    private readonly IFormService _formService;
+    private readonly IFormFieldMasterService _formFieldMasterService;
+    private readonly IFormDataService _formDataService;
+    private readonly ISchemaService _schemaService;
+    private readonly ITransactionService _txService;
+
+    public FormMasterDetailService(
+        SqlConnection connection,
+        IFormService formService,
+        IFormFieldMasterService formFieldMasterService,
+        IFormDataService formDataService,
+        ISchemaService schemaService,
+        ITransactionService txService)
+    {
+        _con = connection;
+        _formService = formService;
+        _formFieldMasterService = formFieldMasterService;
+        _formDataService = formDataService;
+        _schemaService = schemaService;
+        _txService = txService;
+    }
+
+    /// <inheritdoc />
+    public List<FormListDataViewModel> GetFormList(FormSearchRequest? request = null)
+    {
+        return _formService.GetFormList(request);
+    }
+
+    /// <inheritdoc />
+    public FormMasterDetailSubmissionViewModel GetFormSubmission(Guid formMasterDetailId, string? pk = null)
+    {
+        // 取得主明細表頭設定，包含主表與明細表的 FormId
+        var header = _formFieldMasterService.GetFormFieldMasterFromId(formMasterDetailId);
+        var masterVm = _formService.GetFormSubmission(header.MASTER_TABLE_ID, pk);
+
+        var result = new FormMasterDetailSubmissionViewModel
+        {
+            Master = masterVm,
+            Details = new List<FormSubmissionViewModel>()
+        };
+
+        // 若為新增，僅回傳空白的明細欄位模板
+        if (string.IsNullOrEmpty(pk))
+        {
+            var emptyDetail = _formService.GetFormSubmission(header.DETAIL_TABLE_ID);
+            result.Details.Add(emptyDetail);
+            return result;
+        }
+
+        // 取得主表主鍵欄位名稱，同時做為明細表關聯欄位
+        var relationColumn = _schemaService.GetPrimaryKeyColumn(header.MASTER_TABLE_NAME);
+        if (relationColumn == null)
+            throw new InvalidOperationException("Master table has no primary key.");
+
+        // 取得明細表主鍵欄位名稱
+        var detailPk = _schemaService.GetPrimaryKeyColumn(header.DETAIL_TABLE_NAME);
+        if (detailPk == null)
+            throw new InvalidOperationException("Detail table has no primary key.");
+
+        // 先撈出所有符合關聯欄位值的明細資料列
+        var rows = _formDataService.GetRows(
+            header.DETAIL_TABLE_NAME,
+            new List<FormQueryCondition>
+            {
+                new FormQueryCondition
+                {
+                    Column = relationColumn,
+                    ConditionType = ConditionType.Equal,
+                    Value = pk,
+                    DataType = "string"
+                }
+            });
+
+        foreach (var row in rows)
+        {
+            var detailPkValue = row[detailPk]?.ToString();
+            var detailVm = _formService.GetFormSubmission(header.DETAIL_TABLE_ID, detailPkValue);
+            result.Details.Add(detailVm);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public void SubmitForm(FormMasterDetailSubmissionInputModel input)
+    {
+        _txService.WithTransaction(tx =>
+        {
+            // 取得主明細表頭
+            var header = _formFieldMasterService.GetFormFieldMasterFromId(input.FormId, tx);
+
+            // 取得關聯欄位在主表與明細表的 FieldConfig ID
+            var masterCfgId = _con.ExecuteScalar<Guid?>(
+                "SELECT ID FROM FORM_FIELD_CONFIG WHERE FORM_FIELD_Master_ID = @Id AND COLUMN_NAME = @Col",
+                new { Id = header.MASTER_TABLE_ID, Col = input.RelationColumn }, transaction: tx)
+                ?? throw new InvalidOperationException("Master relation column not found.");
+            var detailCfgId = _con.ExecuteScalar<Guid?>(
+                "SELECT ID FROM FORM_FIELD_CONFIG WHERE FORM_FIELD_Master_ID = @Id AND COLUMN_NAME = @Col",
+                new { Id = header.DETAIL_TABLE_ID, Col = input.RelationColumn }, transaction: tx)
+                ?? throw new InvalidOperationException("Detail relation column not found.");
+
+            // 將關聯欄位補入主表資料後提交
+            input.MasterFields.Add(new FormInputField
+            {
+                FieldConfigId = masterCfgId,
+                Value = input.RelationValue
+            });
+
+            var masterInput = new FormSubmissionInputModel
+            {
+                FormId = header.MASTER_TABLE_ID,
+                Pk = input.MasterPk,
+                InputFields = input.MasterFields
+            };
+            _formService.SubmitForm(masterInput);
+
+            // 明細資料逐筆處理
+            foreach (var row in input.DetailRows)
+            {
+                row.Fields.Add(new FormInputField
+                {
+                    FieldConfigId = detailCfgId,
+                    Value = input.RelationValue
+                });
+
+                var detailInput = new FormSubmissionInputModel
+                {
+                    FormId = header.DETAIL_TABLE_ID,
+                    Pk = row.Pk,
+                    InputFields = row.Fields
+                };
+                _formService.SubmitForm(detailInput);
+            }
+        });
+    }
+}

--- a/Areas/Form/ViewModels/FormMasterDetailSubmissionInputModel.cs
+++ b/Areas/Form/ViewModels/FormMasterDetailSubmissionInputModel.cs
@@ -13,12 +13,6 @@ public class FormMasterDetailSubmissionInputModel
     /// <summary>主表資料主鍵，新增時可為 null。</summary>
     public string? MasterPk { get; set; }
 
-    /// <summary>主表與明細表連結欄位名稱，例如 TOL_NO。</summary>
-    public string RelationColumn { get; set; } = string.Empty;
-
-    /// <summary>連結欄位的值。</summary>
-    public string RelationValue { get; set; } = string.Empty;
-
     /// <summary>主表欄位資料。</summary>
     public List<FormInputField> MasterFields { get; set; } = new();
 

--- a/Areas/Form/ViewModels/FormMasterDetailSubmissionInputModel.cs
+++ b/Areas/Form/ViewModels/FormMasterDetailSubmissionInputModel.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace DcMateH5Api.Areas.Form.ViewModels;
+
+/// <summary>
+/// 主明細表提交的輸入模型。
+/// </summary>
+public class FormMasterDetailSubmissionInputModel
+{
+    /// <summary>主明細表頭的 FORM_FIELD_Master.ID。</summary>
+    public Guid FormId { get; set; }
+
+    /// <summary>主表資料主鍵，新增時可為 null。</summary>
+    public string? MasterPk { get; set; }
+
+    /// <summary>主表與明細表連結欄位名稱，例如 TOL_NO。</summary>
+    public string RelationColumn { get; set; } = string.Empty;
+
+    /// <summary>連結欄位的值。</summary>
+    public string RelationValue { get; set; } = string.Empty;
+
+    /// <summary>主表欄位資料。</summary>
+    public List<FormInputField> MasterFields { get; set; } = new();
+
+    /// <summary>明細表列資料。</summary>
+    public List<FormDetailRowInputModel> DetailRows { get; set; } = new();
+}
+
+/// <summary>
+/// 明細表單列資料的輸入模型。
+/// </summary>
+public class FormDetailRowInputModel
+{
+    /// <summary>明細資料主鍵，新增時可為 null。</summary>
+    public string? Pk { get; set; }
+
+    /// <summary>明細欄位資料。</summary>
+    public List<FormInputField> Fields { get; set; } = new();
+}

--- a/Areas/Form/ViewModels/FormMasterDetailSubmissionViewModel.cs
+++ b/Areas/Form/ViewModels/FormMasterDetailSubmissionViewModel.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace DcMateH5Api.Areas.Form.ViewModels;
+
+/// <summary>
+/// 回傳主表與明細表填寫資料的 ViewModel。
+/// </summary>
+public class FormMasterDetailSubmissionViewModel
+{
+    /// <summary>主表資料。</summary>
+    public FormSubmissionViewModel Master { get; set; } = null!;
+
+    /// <summary>明細表資料清單。</summary>
+    public List<FormSubmissionViewModel> Details { get; set; } = new();
+}

--- a/Areas/Form/ViewModels/FormSubmissionInputModel.cs
+++ b/Areas/Form/ViewModels/FormSubmissionInputModel.cs
@@ -8,7 +8,7 @@ namespace DcMateH5Api.Areas.Form.ViewModels;
 /// </summary>
 public class FormSubmissionInputModel
 {
-    public Guid FormId { get; set; }
+    public Guid? FormId { get; set; }
     public string? Pk { get; set; }
     public string? TargetTableToUpsert { get; set; }
     public List<FormInputField> InputFields { get; set; } = new();

--- a/Program.cs
+++ b/Program.cs
@@ -82,6 +82,7 @@ builder.Services.AddScoped<IFormFieldConfigService, FormFieldConfigService>();
 builder.Services.AddScoped<IDropdownService, DropdownService>();
 builder.Services.AddScoped<IFormDataService, FormDataService>();
 builder.Services.AddScoped<IFormService, FormService>();
+builder.Services.AddScoped<IFormMasterDetailService, FormMasterDetailService>();
 builder.Services.AddScoped<IPermissionService, PermissionService>();
 builder.Services.AddScoped<ITransactionService, TransactionService>();
 

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -8,6 +8,9 @@
   "DropdownSql": {
     "IdColumnName": "ID"
   },
+  "FormSettings": {
+    "RelationColumnSuffix": "_NO"
+  },
   "FormDesignerSettings": {
     "RequiredColumns": [ "CREATE_USER", "CREATE_TIME", "EDIT_USER", "EDIT_TIME" ]
   },

--- a/appsettings.json
+++ b/appsettings.json
@@ -11,6 +11,9 @@
   "DropdownSqlSettings": {
     "ExcludeColumns": [ "ID", "SID" ]
   },
+  "FormSettings": {
+    "RelationColumnSuffix": "_NO"
+  },
   "FormDesignerSettings": {
     "RequiredColumns": [ "CREATE_USER", "CREATE_TIME", "EDIT_USER", "EDIT_TIME" ]
   },


### PR DESCRIPTION
## Summary
- implement FormMasterDetailService to coordinate master/detail CRUD operations
- add FormMasterDetailController and view models for master-detail submissions
- register master-detail service in DI container

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found; global.json requires 10.0.100-preview.6.25358.103)*

------
https://chatgpt.com/codex/tasks/task_e_68be66e6dda883209d186f1253fc2604