### PR TITLE
feat: enforce transaction in master-detail form submission

### DIFF
--- a/Areas/Form/Controllers/FormMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormMasterDetailController.cs
@@ -53,11 +53,66 @@ public class FormMasterDetailController : ControllerBase
         var vm = _service.GetFormSubmission(formId, pk);
         return Ok(vm);
     }
-
+    
     /// <summary>
-    /// 提交主表與明細表資料。
+    /// 提交主表與明細表資料
     /// </summary>
-    /// <param name="input">一定要記得帶TOL_NO的FieldConfigId</param>
+    /// <remarks>
+    /// ### 使用說明
+    ///
+    /// 此 API 用於提交主檔與明細檔資料，規則如下：  
+    ///
+    /// 1. **RelationColumn**（例如 `TOL_NO`）是主從關聯欄位，名稱由設定推得，不一定叫 `TOL_NO`。  
+    /// 2. **新增主檔**：當 `MasterPk` 為空時，必須在 `MasterFields` 帶入 RelationColumn 的 `FieldConfigId` 與 `Value`；
+    ///    系統不會自動產生 Relation 值，缺少就會報錯。  
+    /// 3. **新增/更新判斷**：  
+    ///    - 主檔：`MasterPk` 有值 → 更新（僅當 `MasterFields` 有欄位才會更新）；`MasterPk` 空 → 新增。  
+    ///    - 明細：每筆 `Detail.Pk` 獨立判斷；空 → 新增，有值 → 更新（可混搭）。  
+    /// 4. **一致性**：在寫入任何明細前，系統會強制將明細的 RelationColumn 覆蓋為主檔的 Relation 值；
+    ///    即使前端送不同值也會被覆蓋，避免明細被綁錯主檔。  
+    /// 5. **設定要求**：請確保「明細的 RelationColumn」在 `FORM_FIELD_CONFIG` 中設為 `IS_EDITABLE = 1`；
+    ///    否則該欄位會在單表提交時被忽略，導致無法寫入 FK。  
+    ///
+    /// ### 範例請求 (Version 1.0.0)
+    /// 下列 JSON 範例展示了新增主檔及兩筆明細的提交格式：  
+    ///
+    /// ```json
+    /// {
+    ///   "BaseId": "3FA85F64-5717-4562-B3FC-2C963F66AFA1",
+    ///   "MasterPk": "",
+    ///   "MasterFields": [
+    ///     {
+    ///       "FieldConfigId": "7ebcfe8b-ddad-4170-aa28-5f0762efafc3",
+    ///       "Value": "測試新增TOL_NAME"
+    ///     },
+    ///     {
+    ///       "FieldConfigId": "AE2312F9-17FB-4A9D-B7AE-EC933A447D50",
+    ///       "Value": "關聯欄位(這邊是TOL_NO)"
+    ///     }
+    ///   ],
+    ///   "DetailRows": [
+    ///     {
+    ///       "Pk": "",
+    ///       "Fields": [
+    ///         {
+    ///           "FieldConfigId": "0d42dba7-9afb-4d80-b440-c9e6dcb1cc03",
+    ///           "Value": "測試新增TOL_DETALS_NAME1"
+    ///         }
+    ///       ]
+    ///     },
+    ///     {
+    ///       "Pk": "",
+    ///       "Fields": [
+    ///         {
+    ///           "FieldConfigId": "0d42dba7-9afb-4d80-b440-c9e6dcb1cc03",
+    ///           "Value": "測試新增TOL_DETALS_NAME2"
+    ///         }
+    ///       ]
+    ///     }
+    ///   ]
+    /// }
+    /// ```
+    /// </remarks>
     [HttpPost]
     public IActionResult SubmitForm([FromBody] FormMasterDetailSubmissionInputModel input)
     {

--- a/Areas/Form/Interfaces/IFormService.cs
+++ b/Areas/Form/Interfaces/IFormService.cs
@@ -1,6 +1,7 @@
 ﻿using DcMateH5Api.Areas.Form.Models;
 using DcMateH5Api.Areas.Form.ViewModels;
 using ClassLibrary;
+using Microsoft.Data.SqlClient;
 
 namespace DcMateH5Api.Areas.Form.Interfaces;
 
@@ -26,4 +27,11 @@ public interface IFormService
     /// 儲存或更新表單資料
     /// </summary>
     void SubmitForm(FormSubmissionInputModel input);
+
+    /// <summary>
+    /// 儲存或更新表單資料，允許呼叫端提供交易物件以便進行複合交易控制。
+    /// </summary>
+    /// <param name="input">前端送出的表單資料</param>
+    /// <param name="tx">資料庫交易物件</param>
+    void SubmitForm(FormSubmissionInputModel input, SqlTransaction tx);
 }

--- a/Areas/Form/Services/FormMasterDetailService.cs
+++ b/Areas/Form/Services/FormMasterDetailService.cs
@@ -123,87 +123,90 @@ public class FormMasterDetailService : IFormMasterDetailService
     /// </summary>
     public void SubmitForm(FormMasterDetailSubmissionInputModel input)
     {
-        // 1) 讀設定：找出主檔/明細要用的關聯欄位名稱
-        var header = _formFieldMasterService.GetFormFieldMasterFromId(input.BaseId, null)
-                     ?? throw new InvalidOperationException($"Form master not found: {input.BaseId}");
-
-        var relationColumn = GetRelationColumn(header.BASE_TABLE_NAME!, header.DETAIL_TABLE_NAME!);
-
-        // 2) 查出「關聯欄位」在 config 中對應的 ConfigId（Master / Detail 各一）
-        var masterCfgId = _con.ExecuteScalar<Guid?>(@"/**/
-        SELECT ID FROM FORM_FIELD_CONFIG 
-        WHERE FORM_FIELD_Master_ID = @Id AND COLUMN_NAME = @Col",
-                              new { Id = header.BASE_TABLE_ID, Col = relationColumn })
-                          ?? throw new InvalidOperationException("Master relation column not found.");
-
-        var detailCfgId = _con.ExecuteScalar<Guid?>(@"/**/
-        SELECT ID FROM FORM_FIELD_CONFIG 
-        WHERE FORM_FIELD_Master_ID = @Id AND COLUMN_NAME = @Col",
-                              new { Id = header.DETAIL_TABLE_ID, Col = relationColumn })
-                          ?? throw new InvalidOperationException("Detail relation column not found.");
-        
-        // 3) 優先從 MasterFields 嘗試取得 relationValue（若前端已送）
-        object? relationValue = input.MasterFields .FirstOrDefault(f => f.FieldConfigId == masterCfgId)?.Value;
-
-        // 4) 分兩種情境
-        if (!string.IsNullOrEmpty(input.MasterPk))
+        _txService.WithTransaction(tx =>
         {
-            // Case A：Master 已存在（MasterPk 有值）
-            // 若 relationValue 還沒有，就用 MasterPk 回查 DB 的 relationColumn
-            if (relationValue is null)
-            {
-                var (pkName, _, pkVal) = _schemaService.ResolvePk(header.BASE_TABLE_NAME!, input.MasterPk);
-                relationValue = _con.ExecuteScalar<object?>(@"/**/
-SELECT [{relationColumn}] FROM [{header.BASE_TABLE_NAME}] WHERE [{pkName}] = @id", new { id = pkVal })
-                                ?? throw new InvalidOperationException($"Master not found by PK: {input.MasterPk}");
-            }
+            // 1) 讀設定：找出主檔/明細要用的關聯欄位名稱
+            var header = _formFieldMasterService.GetFormFieldMasterFromId(input.BaseId, tx)
+                         ?? throw new InvalidOperationException($"Form master not found: {input.BaseId}");
 
-            // 若有 Master 欄位要改，交給既有單表 Submit
-            if (input.MasterFields.Count > 0)
+            var relationColumn = GetRelationColumn(header.BASE_TABLE_NAME!, header.DETAIL_TABLE_NAME!);
+
+            // 2) 查出「關聯欄位」在 config 中對應的 ConfigId（Master / Detail 各一）
+            var masterCfgId = _con.ExecuteScalar<Guid?>(@"/**/
+        SELECT ID FROM FORM_FIELD_CONFIG
+        WHERE FORM_FIELD_Master_ID = @Id AND COLUMN_NAME = @Col",
+                                  new { Id = header.BASE_TABLE_ID, Col = relationColumn }, transaction: tx)
+                              ?? throw new InvalidOperationException("Master relation column not found.");
+
+            var detailCfgId = _con.ExecuteScalar<Guid?>(@"/**/
+        SELECT ID FROM FORM_FIELD_CONFIG
+        WHERE FORM_FIELD_Master_ID = @Id AND COLUMN_NAME = @Col",
+                                  new { Id = header.DETAIL_TABLE_ID, Col = relationColumn }, transaction: tx)
+                              ?? throw new InvalidOperationException("Detail relation column not found.");
+
+            // 3) 優先從 MasterFields 嘗試取得 relationValue（若前端已送）
+            object? relationValue = input.MasterFields.FirstOrDefault(f => f.FieldConfigId == masterCfgId)?.Value;
+
+            // 4) 分兩種情境
+            if (!string.IsNullOrEmpty(input.MasterPk))
             {
-                var masterUpdate = new FormSubmissionInputModel
+                // Case A：Master 已存在（MasterPk 有值）
+                // 若 relationValue 還沒有，就用 MasterPk 回查 DB 的 relationColumn
+                if (relationValue is null)
                 {
-                    BaseId = header.BASE_TABLE_ID,
-                    Pk = input.MasterPk,
-                    InputFields = input.MasterFields
-                };
-                _formService.SubmitForm(masterUpdate);
-            }
-        }
-        else
-        {
-            // Case B：Master 要新增（MasterPk 空）
-            if (relationValue is null)
-            {
-                throw new InvalidOperationException($"關聯鍵的FieldConfigId遺失，無法插入關聯欄位");
+                    var (pkName, _, pkVal) = _schemaService.ResolvePk(header.BASE_TABLE_NAME!, input.MasterPk, tx);
+                    relationValue = _con.ExecuteScalar<object?>(@"/**/
+SELECT [{relationColumn}] FROM [{header.BASE_TABLE_NAME}] WHERE [{pkName}] = @id", new { id = pkVal }, transaction: tx)
+                                    ?? throw new InvalidOperationException($"Master not found by PK: {input.MasterPk}");
+                }
+
+                // 若有 Master 欄位要改，交給既有單表 Submit
+                if (input.MasterFields.Count > 0)
+                {
+                    var masterUpdate = new FormSubmissionInputModel
+                    {
+                        BaseId = header.BASE_TABLE_ID,
+                        Pk = input.MasterPk,
+                        InputFields = input.MasterFields
+                    };
+                    _formService.SubmitForm(masterUpdate, tx);
+                }
             }
             else
             {
-                // 前端已送 relationValue（例如非 PK 的自然鍵）
-                // 直接新增 Master（不需要再取 PK），用既有單表 Submit
-                var masterInsert = new FormSubmissionInputModel
+                // Case B：Master 要新增（MasterPk 空）
+                if (relationValue is null)
                 {
-                    BaseId = header.BASE_TABLE_ID,
-                    Pk = null,
-                    InputFields = input.MasterFields
-                };
-                _formService.SubmitForm(masterInsert); // 沿用你現有方法
+                    throw new InvalidOperationException($"關聯鍵的FieldConfigId遺失，無法插入關聯欄位");
+                }
+                else
+                {
+                    // 前端已送 relationValue（例如非 PK 的自然鍵）
+                    // 直接新增 Master（不需要再取 PK），用既有單表 Submit
+                    var masterInsert = new FormSubmissionInputModel
+                    {
+                        BaseId = header.BASE_TABLE_ID,
+                        Pk = null,
+                        InputFields = input.MasterFields
+                    };
+                    _formService.SubmitForm(masterInsert, tx); // 沿用你現有方法
+                }
             }
-        }
 
-        // 5) 明細：一律強制帶上 relationValue（覆蓋前端，避免被移到其他 Master）
-        foreach (var row in input.DetailRows)
-        {
-            UpsertField(row.Fields, detailCfgId, relationValue, overwrite: true);
-
-            var detailInput = new FormSubmissionInputModel
+            // 5) 明細：一律強制帶上 relationValue（覆蓋前端，避免被移到其他 Master）
+            foreach (var row in input.DetailRows)
             {
-                BaseId = header.DETAIL_TABLE_ID,
-                Pk = string.IsNullOrWhiteSpace(row.Pk) ? null : row.Pk,
-                InputFields = row.Fields
-            };
-            _formService.SubmitForm(detailInput); 
-        }
+                UpsertField(row.Fields, detailCfgId, relationValue, overwrite: true);
+
+                var detailInput = new FormSubmissionInputModel
+                {
+                    BaseId = header.DETAIL_TABLE_ID,
+                    Pk = string.IsNullOrWhiteSpace(row.Pk) ? null : row.Pk,
+                    InputFields = row.Fields
+                };
+                _formService.SubmitForm(detailInput, tx);
+            }
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- ensure FormMasterDetailService.SubmitForm runs master and detail operations in a single transaction
- allow FormService.SubmitForm to reuse existing SqlTransaction via new overload
- expose transaction-enabled SubmitForm in IFormService for composite operations

## Testing
- `dotnet test` *(fails: .NET SDK 10.0.100-preview.6.25358.103 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ee072a748320b2bd0f80f6bca50f