### PR TITLE
Include raw detail data in master-detail rows

### DIFF
--- a/Areas/Form/Controllers/FormMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormMasterDetailController.cs
@@ -53,7 +53,18 @@ public class FormMasterDetailController : ControllerBase
         var vm = _service.GetFormSubmission(formId, pk);
         return Ok(vm);
     }
-    
+
+    /// <summary>
+    /// 取得指定主明細設定下所有明細資料列，供資料轉移或比對使用。
+    /// </summary>
+    /// <param name="formId">主明細表頭的 FORM_FIELD_Master.ID。</param>
+    [HttpGet("{formId:guid}/details")]
+    public IActionResult GetDetailRows(Guid formId)
+    {
+        var rows = _service.GetAllDetailRows(formId);
+        return Ok(rows);
+    }
+
     /// <summary>
     /// 提交主表與明細表資料
     /// </summary>

--- a/Areas/Form/Controllers/FormMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormMasterDetailController.cs
@@ -17,7 +17,7 @@ namespace DcMateH5Api.Areas.Form.Controllers;
 public class FormMasterDetailController : ControllerBase
 {
     private const int DefaultDetailPage = 1;
-    private const int DefaultDetailPageSize = 50;
+    private const int DefaultDetailPageSize = 10;
 
     private readonly IFormMasterDetailService _service;
     private readonly FormFunctionType _funcType = FormFunctionType.MasterDetail;
@@ -67,17 +67,6 @@ public class FormMasterDetailController : ControllerBase
     public IActionResult GetDetailRows(Guid formId, [FromQuery] int page = DefaultDetailPage, [FromQuery] int pageSize = DefaultDetailPageSize)
     {
         var rows = _service.GetDetailRows(formId, page, pageSize);
-        return Ok(rows);
-    }
-
-    /// <summary>
-    /// 取得指定主明細設定的所有明細資料列，供批次轉移或比對使用。
-    /// </summary>
-    /// <param name="formId">主明細表頭的 FORM_FIELD_Master.ID。</param>
-    [HttpGet("{formId:guid}/details/all")]
-    public IActionResult GetAllDetailRows(Guid formId)
-    {
-        var rows = _service.GetAllDetailRows(formId);
         return Ok(rows);
     }
 

--- a/Areas/Form/Controllers/FormMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormMasterDetailController.cs
@@ -71,6 +71,17 @@ public class FormMasterDetailController : ControllerBase
     }
 
     /// <summary>
+    /// 取得指定主明細設定的所有明細資料列，供批次轉移或比對使用。
+    /// </summary>
+    /// <param name="formId">主明細表頭的 FORM_FIELD_Master.ID。</param>
+    [HttpGet("{formId:guid}/details/all")]
+    public IActionResult GetAllDetailRows(Guid formId)
+    {
+        var rows = _service.GetAllDetailRows(formId);
+        return Ok(rows);
+    }
+
+    /// <summary>
     /// 提交主表與明細表資料
     /// </summary>
     /// <remarks>

--- a/Areas/Form/Interfaces/IFormMasterDetailService.cs
+++ b/Areas/Form/Interfaces/IFormMasterDetailService.cs
@@ -39,4 +39,11 @@ public interface IFormMasterDetailService
     /// <param name="pageSize">每頁筆數。</param>
     /// <returns>分頁後的明細列資料。</returns>
     FormDetailRowPageViewModel GetDetailRows(Guid formMasterDetailId, int page, int pageSize);
+
+    /// <summary>
+    /// 取得指定主明細設定下所有明細資料列。
+    /// </summary>
+    /// <param name="formMasterDetailId">主明細表單的 FORM_FIELD_Master.ID。</param>
+    /// <returns>所有明細列資料。</returns>
+    List<FormDetailRowViewModel> GetAllDetailRows(Guid formMasterDetailId);
 }

--- a/Areas/Form/Interfaces/IFormMasterDetailService.cs
+++ b/Areas/Form/Interfaces/IFormMasterDetailService.cs
@@ -1,8 +1,6 @@
 using ClassLibrary;
 using DcMateH5Api.Areas.Form.Models;
-using DcMateH5Api.Areas.Form.Services;
 using DcMateH5Api.Areas.Form.ViewModels;
-using Microsoft.Data.SqlClient;
 
 namespace DcMateH5Api.Areas.Form.Interfaces;
 
@@ -34,9 +32,11 @@ public interface IFormMasterDetailService
     void SubmitForm(FormMasterDetailSubmissionInputModel input);
 
     /// <summary>
-    /// 取得指定主明細設定下所有明細資料列。
+    /// 依分頁取得指定主明細設定下的明細資料列。
     /// </summary>
     /// <param name="formMasterDetailId">主明細表單的 FORM_FIELD_Master.ID。</param>
-    /// <returns>所有明細列的主鍵與欄位值。</returns>
-    List<FormDetailRowViewModel> GetAllDetailRows(Guid formMasterDetailId);
+    /// <param name="page">頁碼（從 1 起算）。</param>
+    /// <param name="pageSize">每頁筆數。</param>
+    /// <returns>分頁後的明細列資料。</returns>
+    FormDetailRowPageViewModel GetDetailRows(Guid formMasterDetailId, int page, int pageSize);
 }

--- a/Areas/Form/Interfaces/IFormMasterDetailService.cs
+++ b/Areas/Form/Interfaces/IFormMasterDetailService.cs
@@ -32,4 +32,11 @@ public interface IFormMasterDetailService
     /// </summary>
     /// <param name="input">主明細表單的提交資料。</param>
     void SubmitForm(FormMasterDetailSubmissionInputModel input);
+
+    /// <summary>
+    /// 取得指定主明細設定下所有明細資料列。
+    /// </summary>
+    /// <param name="formMasterDetailId">主明細表單的 FORM_FIELD_Master.ID。</param>
+    /// <returns>所有明細列的主鍵與欄位值。</returns>
+    List<FormDetailRowViewModel> GetAllDetailRows(Guid formMasterDetailId);
 }

--- a/Areas/Form/Interfaces/IFormMasterDetailService.cs
+++ b/Areas/Form/Interfaces/IFormMasterDetailService.cs
@@ -39,11 +39,4 @@ public interface IFormMasterDetailService
     /// <param name="pageSize">每頁筆數。</param>
     /// <returns>分頁後的明細列資料。</returns>
     FormDetailRowPageViewModel GetDetailRows(Guid formMasterDetailId, int page, int pageSize);
-
-    /// <summary>
-    /// 取得指定主明細設定下所有明細資料列。
-    /// </summary>
-    /// <param name="formMasterDetailId">主明細表單的 FORM_FIELD_Master.ID。</param>
-    /// <returns>所有明細列資料。</returns>
-    List<FormDetailRowViewModel> GetAllDetailRows(Guid formMasterDetailId);
 }

--- a/Areas/Form/Services/FormMasterDetailService.cs
+++ b/Areas/Form/Services/FormMasterDetailService.cs
@@ -168,6 +168,7 @@ ORDER BY FIELD_ORDER", new { Id = header.DETAIL_TABLE_ID })
                 Page = safePage,
                 PageSize = trimmedPageSize,
                 TotalCount = 0,
+                RelationColumn = relationColumn,
                 Rows = new List<FormDetailRowViewModel>()
             };
         }
@@ -186,6 +187,7 @@ ORDER BY FIELD_ORDER", new { Id = header.DETAIL_TABLE_ID })
                 Page = safePage,
                 PageSize = trimmedPageSize,
                 TotalCount = 0,
+                RelationColumn = relationColumn,
                 Rows = new List<FormDetailRowViewModel>()
             };
         }
@@ -211,6 +213,7 @@ ORDER BY FIELD_ORDER", new { Id = header.DETAIL_TABLE_ID })
             Page = safePage,
             PageSize = trimmedPageSize,
             TotalCount = totalCount,
+            RelationColumn = relationColumn,
             Rows = projectedRows
         };
     }

--- a/Areas/Form/ViewModels/FormDetailRowPageViewModel.cs
+++ b/Areas/Form/ViewModels/FormDetailRowPageViewModel.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace DcMateH5Api.Areas.Form.ViewModels;
+
+/// <summary>
+/// 封裝明細列的分頁結果。
+/// </summary>
+public class FormDetailRowPageViewModel
+{
+    /// <summary>目前頁碼（從 1 起算）。</summary>
+    public int Page { get; set; }
+
+    /// <summary>每頁筆數。</summary>
+    public int PageSize { get; set; }
+
+    /// <summary>總筆數，供前端計算頁數。</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>當前頁面的明細列。</summary>
+    public List<FormDetailRowViewModel> Rows { get; set; } = new();
+}

--- a/Areas/Form/ViewModels/FormDetailRowPageViewModel.cs
+++ b/Areas/Form/ViewModels/FormDetailRowPageViewModel.cs
@@ -16,6 +16,9 @@ public class FormDetailRowPageViewModel
     /// <summary>總筆數，供前端計算頁數。</summary>
     public int TotalCount { get; set; }
 
+    /// <summary>主檔與明細的關聯欄位名稱。</summary>
+    public string RelationColumn { get; set; } = string.Empty;
+
     /// <summary>當前頁面的明細列。</summary>
     public List<FormDetailRowViewModel> Rows { get; set; } = new();
 }

--- a/Areas/Form/ViewModels/FormDetailRowViewModel.cs
+++ b/Areas/Form/ViewModels/FormDetailRowViewModel.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace DcMateH5Api.Areas.Form.ViewModels;
+
+/// <summary>
+/// 提供明細列資料給前端顯示或轉移使用。
+/// </summary>
+public class FormDetailRowViewModel
+{
+    /// <summary>明細資料主鍵。</summary>
+    public string? Pk { get; set; }
+
+    /// <summary>欄位與值的對應清單。</summary>
+    public List<FormInputField> Fields { get; set; } = new();
+
+    /// <summary>原始資料庫欄位值對應表。</summary>
+    public Dictionary<string, object?> RawData { get; set; } =
+        new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+}

--- a/Areas/Form/ViewModels/FormInputField.cs
+++ b/Areas/Form/ViewModels/FormInputField.cs
@@ -6,6 +6,12 @@ namespace DcMateH5Api.Areas.Form.ViewModels;
 public class FormInputField
 {
     public Guid FieldConfigId { get; set; }
+
+    /// <summary>
+    /// 資料庫欄位名稱，供前端識別欄位用途（例如關聯鍵）。
+    /// </summary>
+    public string? ColumnName { get; set; }
+
     public string? Value { get; set; }
 }
 


### PR DESCRIPTION
## Summary
- include raw detail table payload in the detail-row listing response for transfer workflows
- normalize database nulls when projecting raw data and serialized field values to keep outputs consistent

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d613747f688320be95dac6e3a3f52c