### PR TITLE
Expose relation field config id in detail row responses

### DIFF
--- a/Areas/Form/Controllers/FormMasterDetailController.cs
+++ b/Areas/Form/Controllers/FormMasterDetailController.cs
@@ -16,6 +16,9 @@ namespace DcMateH5Api.Areas.Form.Controllers;
 [Route("[area]/[controller]")]
 public class FormMasterDetailController : ControllerBase
 {
+    private const int DefaultDetailPage = 1;
+    private const int DefaultDetailPageSize = 50;
+
     private readonly IFormMasterDetailService _service;
     private readonly FormFunctionType _funcType = FormFunctionType.MasterDetail;
     public FormMasterDetailController(IFormMasterDetailService service)
@@ -53,28 +56,52 @@ public class FormMasterDetailController : ControllerBase
         var vm = _service.GetFormSubmission(formId, pk);
         return Ok(vm);
     }
-    
+
+    /// <summary>
+    /// 取得指定主明細設定下所有明細資料列，供資料轉移或比對使用。
+    /// </summary>
+    /// <param name="formId">主明細表頭的 FORM_FIELD_Master.ID。</param>
+    /// <param name="page">頁碼（從 1 起算）。</param>
+    /// <param name="pageSize">每頁筆數。</param>
+    [HttpGet("{formId:guid}/details")]
+    public IActionResult GetDetailRows(Guid formId, [FromQuery] int page = DefaultDetailPage, [FromQuery] int pageSize = DefaultDetailPageSize)
+    {
+        var rows = _service.GetDetailRows(formId, page, pageSize);
+        return Ok(rows);
+    }
+
+    /// <summary>
+    /// 取得指定主明細設定的所有明細資料列，供批次轉移或比對使用。
+    /// </summary>
+    /// <param name="formId">主明細表頭的 FORM_FIELD_Master.ID。</param>
+    [HttpGet("{formId:guid}/details/all")]
+    public IActionResult GetAllDetailRows(Guid formId)
+    {
+        var rows = _service.GetAllDetailRows(formId);
+        return Ok(rows);
+    }
+
     /// <summary>
     /// 提交主表與明細表資料
     /// </summary>
     /// <remarks>
     /// ### 使用說明
     ///
-    /// 此 API 用於提交主檔與明細檔資料，規則如下：  
+    /// 此 API 用於提交主檔與明細檔資料，規則如下：
     ///
-    /// 1. **RelationColumn**（例如 `TOL_NO`）是主從關聯欄位，名稱由設定推得，不一定叫 `TOL_NO`。  
+    /// 1. **RelationColumn**（例如 `TOL_NO`）是主從關聯欄位，名稱由設定推得，不一定叫 `TOL_NO`。
     /// 2. **新增主檔**：當 `MasterPk` 為空時，不一定要在 `MasterFields` 帶入 RelationColumn 的 `FieldConfigId` 與 `Value`；
-    ///    設定時，缺少 Relation 值，像是主明細應該要都有的 `TOL_NO` ，就會報錯。  
-    /// 3. **新增/更新判斷**：  
-    ///    - 主檔：`MasterPk` 有值 → 更新（僅當 `MasterFields` 有欄位才會更新）；`MasterPk` 空 → 新增。  
-    ///    - 明細：每筆 `Detail.Pk` 獨立判斷；空 → 新增，有值 → 更新（可混搭）。  
+    ///    設定時，缺少 Relation 值，像是主明細應該要都有的 `TOL_NO` ，就會報錯。
+    /// 3. **新增/更新判斷**：
+    ///    - 主檔：`MasterPk` 有值 → 更新（僅當 `MasterFields` 有欄位才會更新）；`MasterPk` 空 → 新增。
+    ///    - 明細：每筆 `Detail.Pk` 獨立判斷；空 → 新增，有值 → 更新（可混搭）。
     /// 4. **一致性**：在寫入任何明細前，系統會強制將明細的 RelationColumn 覆蓋為主檔的 Relation 值；
-    ///    即使前端送不同值也會被覆蓋，避免明細被綁錯主檔。  
+    ///    即使前端送不同值也會被覆蓋，避免明細被綁錯主檔。
     /// 5. **設定要求**：請確保「明細的 RelationColumn」在 `FORM_FIELD_CONFIG` 中設為 `IS_EDITABLE = 1`；
-    ///    否則該欄位會在單表提交時被忽略，導致無法寫入 FK。  
+    ///    否則該欄位會在單表提交時被忽略，導致無法寫入 FK。
     ///
     /// ### 範例請求 (Version 1.0.0)
-    /// 下列 JSON 範例展示了新增主檔及兩筆明細的提交格式：  
+    /// 下列 JSON 範例展示了新增主檔及兩筆明細的提交格式：
     ///
     /// ```json
     /// {

--- a/Areas/Form/Interfaces/IFormMasterDetailService.cs
+++ b/Areas/Form/Interfaces/IFormMasterDetailService.cs
@@ -1,8 +1,6 @@
 using ClassLibrary;
 using DcMateH5Api.Areas.Form.Models;
-using DcMateH5Api.Areas.Form.Services;
 using DcMateH5Api.Areas.Form.ViewModels;
-using Microsoft.Data.SqlClient;
 
 namespace DcMateH5Api.Areas.Form.Interfaces;
 
@@ -32,4 +30,20 @@ public interface IFormMasterDetailService
     /// </summary>
     /// <param name="input">主明細表單的提交資料。</param>
     void SubmitForm(FormMasterDetailSubmissionInputModel input);
+
+    /// <summary>
+    /// 依分頁取得指定主明細設定下的明細資料列。
+    /// </summary>
+    /// <param name="formMasterDetailId">主明細表單的 FORM_FIELD_Master.ID。</param>
+    /// <param name="page">頁碼（從 1 起算）。</param>
+    /// <param name="pageSize">每頁筆數。</param>
+    /// <returns>分頁後的明細列資料。</returns>
+    FormDetailRowPageViewModel GetDetailRows(Guid formMasterDetailId, int page, int pageSize);
+
+    /// <summary>
+    /// 取得指定主明細設定下所有明細資料列。
+    /// </summary>
+    /// <param name="formMasterDetailId">主明細表單的 FORM_FIELD_Master.ID。</param>
+    /// <returns>所有明細列資料。</returns>
+    List<FormDetailRowViewModel> GetAllDetailRows(Guid formMasterDetailId);
 }

--- a/Areas/Form/Services/FormMasterDetailService.cs
+++ b/Areas/Form/Services/FormMasterDetailService.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
 using ClassLibrary;
 using Dapper;
 using DcMateH5Api.Areas.Form.Interfaces;
@@ -14,6 +19,8 @@ namespace DcMateH5Api.Areas.Form.Services;
 /// </summary>
 public class FormMasterDetailService : IFormMasterDetailService
 {
+    private const int MaxDetailPageSize = 200;
+    private static readonly Regex IdentifierRegex = new("^[A-Za-z0-9_]+$", RegexOptions.Compiled);
     private readonly SqlConnection _con;
     private readonly IFormService _formService;
     private readonly IFormFieldMasterService _formFieldMasterService;
@@ -113,6 +120,228 @@ public class FormMasterDetailService : IFormMasterDetailService
         }
 
         return result;
+    }
+
+    /// <inheritdoc />
+    public FormDetailRowPageViewModel GetDetailRows(Guid formMasterDetailId, int page, int pageSize)
+    {
+        var header = _formFieldMasterService.GetFormFieldMasterFromId(formMasterDetailId)
+                     ?? throw new InvalidOperationException($"Form master not found: {formMasterDetailId}");
+
+        if (string.IsNullOrWhiteSpace(header.BASE_TABLE_NAME))
+        {
+            throw new InvalidOperationException("Master table name is not configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(header.DETAIL_TABLE_NAME) || header.DETAIL_TABLE_ID is null)
+        {
+            throw new InvalidOperationException("Detail table setting is incomplete.");
+        }
+
+        var safePage = page < 1 ? 1 : page;
+        var trimmedPageSize = pageSize < 1 ? 1 : pageSize;
+        if (trimmedPageSize > MaxDetailPageSize)
+        {
+            trimmedPageSize = MaxDetailPageSize;
+        }
+
+        ValidateSqlIdentifier(header.DETAIL_TABLE_NAME!, nameof(header.DETAIL_TABLE_NAME));
+
+        var relationColumn = GetRelationColumn(header.BASE_TABLE_NAME!, header.DETAIL_TABLE_NAME!);
+        ValidateSqlIdentifier(relationColumn, nameof(relationColumn));
+
+        var detailPk = _schemaService.GetPrimaryKeyColumn(header.DETAIL_TABLE_NAME!)
+                       ?? throw new InvalidOperationException("Detail table has no primary key.");
+        ValidateSqlIdentifier(detailPk, nameof(detailPk));
+
+        var configs = _con.Query<(Guid Id, string Column, string DataType, int Order)>(@"/**/
+SELECT ID, COLUMN_NAME, DATA_TYPE, FIELD_ORDER AS [Order]
+FROM FORM_FIELD_CONFIG
+WHERE FORM_FIELD_Master_ID = @Id
+ORDER BY FIELD_ORDER", new { Id = header.DETAIL_TABLE_ID })
+            .ToList();
+
+        if (configs.Count == 0)
+        {
+            return new FormDetailRowPageViewModel
+            {
+                Page = safePage,
+                PageSize = trimmedPageSize,
+                TotalCount = 0,
+                RelationColumn = relationColumn,
+                Rows = new List<FormDetailRowViewModel>()
+            };
+        }
+
+        if (!configs.Any(c => c.Column.Equals(relationColumn, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException(
+                $"Detail relation column '{relationColumn}' has no matching FORM_FIELD_CONFIG entry.");
+        }
+
+        var totalCount = _con.ExecuteScalar<int>($"/**/SELECT COUNT(1) FROM [{header.DETAIL_TABLE_NAME}]");
+        if (totalCount == 0)
+        {
+            return new FormDetailRowPageViewModel
+            {
+                Page = safePage,
+                PageSize = trimmedPageSize,
+                TotalCount = 0,
+                RelationColumn = relationColumn,
+                Rows = new List<FormDetailRowViewModel>()
+            };
+        }
+
+        var columnTypes = _formDataService.LoadColumnTypes(header.DETAIL_TABLE_NAME!);
+
+        var offset = (long)(safePage - 1) * trimmedPageSize;
+        if (offset < 0)
+        {
+            offset = 0;
+        }
+
+        var rows = _con.Query(
+                $"/**/SELECT * FROM [{header.DETAIL_TABLE_NAME}] ORDER BY [{detailPk}] OFFSET @Offset ROWS FETCH NEXT @PageSize ROWS ONLY",
+                new { Offset = offset, PageSize = trimmedPageSize })
+            .Cast<IDictionary<string, object?>>()
+            .ToList();
+
+        var relationConfigId = configs
+            .First(c => c.Column.Equals(relationColumn, StringComparison.OrdinalIgnoreCase))
+            .Id;
+
+        var projectedRows = ProjectDetailRows(rows, detailPk, configs, columnTypes, relationConfigId);
+
+        return new FormDetailRowPageViewModel
+        {
+            Page = safePage,
+            PageSize = trimmedPageSize,
+            TotalCount = totalCount,
+            RelationColumn = relationColumn,
+            Rows = projectedRows
+        };
+    }
+
+    /// <inheritdoc />
+    public List<FormDetailRowViewModel> GetAllDetailRows(Guid formMasterDetailId)
+    {
+        var header = _formFieldMasterService.GetFormFieldMasterFromId(formMasterDetailId)
+                     ?? throw new InvalidOperationException($"Form master not found: {formMasterDetailId}");
+
+        if (string.IsNullOrWhiteSpace(header.BASE_TABLE_NAME))
+        {
+            throw new InvalidOperationException("Master table name is not configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(header.DETAIL_TABLE_NAME) || header.DETAIL_TABLE_ID is null)
+        {
+            throw new InvalidOperationException("Detail table setting is incomplete.");
+        }
+
+        ValidateSqlIdentifier(header.DETAIL_TABLE_NAME!, nameof(header.DETAIL_TABLE_NAME));
+
+        var relationColumn = GetRelationColumn(header.BASE_TABLE_NAME!, header.DETAIL_TABLE_NAME!);
+        ValidateSqlIdentifier(relationColumn, nameof(relationColumn));
+
+        var detailPk = _schemaService.GetPrimaryKeyColumn(header.DETAIL_TABLE_NAME!)
+                       ?? throw new InvalidOperationException("Detail table has no primary key.");
+        ValidateSqlIdentifier(detailPk, nameof(detailPk));
+
+        var configs = _con.Query<(Guid Id, string Column, string DataType, int Order)>(@"/**/
+SELECT ID, COLUMN_NAME, DATA_TYPE, FIELD_ORDER AS [Order]
+FROM FORM_FIELD_CONFIG
+WHERE FORM_FIELD_Master_ID = @Id
+ORDER BY FIELD_ORDER", new { Id = header.DETAIL_TABLE_ID })
+            .ToList();
+
+        if (configs.Count == 0)
+        {
+            return new List<FormDetailRowViewModel>();
+        }
+
+        if (!configs.Any(c => c.Column.Equals(relationColumn, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException(
+                $"Detail relation column '{relationColumn}' has no matching FORM_FIELD_CONFIG entry.");
+        }
+
+        var columnTypes = _formDataService.LoadColumnTypes(header.DETAIL_TABLE_NAME!);
+
+        var relationConfigId = configs
+            .First(c => c.Column.Equals(relationColumn, StringComparison.OrdinalIgnoreCase))
+            .Id;
+
+        var rows = _con.Query(
+                $"/**/SELECT * FROM [{header.DETAIL_TABLE_NAME}] ORDER BY [{detailPk}]")
+            .Cast<IDictionary<string, object?>>()
+            .ToList();
+
+        return ProjectDetailRows(rows, detailPk, configs, columnTypes, relationConfigId);
+    }
+
+    private List<FormDetailRowViewModel> ProjectDetailRows(
+        IEnumerable<IDictionary<string, object?>> rows,
+        string detailPk,
+        IReadOnlyList<(Guid Id, string Column, string DataType, int Order)> configs,
+        IReadOnlyDictionary<string, string> columnTypes,
+        Guid relationConfigId)
+    {
+        var result = new List<FormDetailRowViewModel>();
+
+        foreach (var row in rows)
+        {
+            var normalizedRow = CreateCaseInsensitiveRow(row);
+            normalizedRow.TryGetValue(detailPk, out var pkValue);
+
+            var fields = new List<FormInputField>(configs.Count);
+            var rawData = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var (columnName, columnValue) in normalizedRow)
+            {
+                rawData[columnName] = NormalizeRawValue(columnValue);
+            }
+
+            foreach (var (id, column, dataType, _) in configs)
+            {
+                normalizedRow.TryGetValue(column, out var value);
+                var sqlType = columnTypes.TryGetValue(column, out var mappedType) ? mappedType : dataType;
+                fields.Add(new FormInputField
+                {
+                    FieldConfigId = id,
+                    ColumnName = column,
+                    Value = SerializeValue(value, sqlType)
+                });
+            }
+
+            result.Add(new FormDetailRowViewModel
+            {
+                Pk = pkValue?.ToString(),
+                Fields = fields,
+                RawData = rawData,
+                RelationFieldConfigId = relationConfigId
+            });
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, object?> CreateCaseInsensitiveRow(IDictionary<string, object?> source)
+    {
+        var normalized = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in source)
+        {
+            normalized[key] = value;
+        }
+
+        return normalized;
+    }
+
+    private static void ValidateSqlIdentifier(string identifier, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(identifier) || !IdentifierRegex.IsMatch(identifier))
+        {
+            throw new InvalidOperationException($"{parameterName} contains invalid characters.");
+        }
     }
 
     /// <summary>
@@ -236,6 +465,50 @@ SELECT [{relationColumn}] FROM [{header.BASE_TABLE_NAME}] WHERE [{pkName}] = @id
         {
             f.Value = stringValue;
         }
+    }
+
+    private static object? NormalizeRawValue(object? value)
+    {
+        return value is DBNull ? null : value;
+    }
+
+    private static string? SerializeValue(object? value, string? sqlType)
+    {
+        if (value is DBNull)
+        {
+            return null;
+        }
+
+        if (value is null)
+        {
+            return null;
+        }
+
+        var normalized = sqlType?.ToLowerInvariant();
+
+        return normalized switch
+        {
+            "decimal" or "numeric" or "money" or "smallmoney" or "float" or "real" =>
+                (value as IFormattable)?.ToString(null, CultureInfo.InvariantCulture)
+                ?? Convert.ToString(value, CultureInfo.InvariantCulture),
+            "int" or "bigint" or "smallint" or "tinyint" =>
+                (value as IFormattable)?.ToString(null, CultureInfo.InvariantCulture)
+                ?? Convert.ToString(value, CultureInfo.InvariantCulture),
+            "bit" => value switch
+            {
+                bool b => b ? "1" : "0",
+                byte bt => bt != 0 ? "1" : "0",
+                short s => s != 0 ? "1" : "0",
+                int i => i != 0 ? "1" : "0",
+                long l => l != 0 ? "1" : "0",
+                _ => Convert.ToString(value, CultureInfo.InvariantCulture)
+            },
+            "datetime" or "smalldatetime" or "datetime2" or "date" =>
+                value is DateTime dt
+                    ? dt.ToString("o", CultureInfo.InvariantCulture)
+                    : Convert.ToString(value, CultureInfo.InvariantCulture),
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture)
+        };
     }
 
 }

--- a/Areas/Form/ViewModels/FormDetailRowPageViewModel.cs
+++ b/Areas/Form/ViewModels/FormDetailRowPageViewModel.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace DcMateH5Api.Areas.Form.ViewModels;
+
+/// <summary>
+/// 封裝明細列的分頁結果。
+/// </summary>
+public class FormDetailRowPageViewModel
+{
+    /// <summary>目前頁碼（從 1 起算）。</summary>
+    public int Page { get; set; }
+
+    /// <summary>每頁筆數。</summary>
+    public int PageSize { get; set; }
+
+    /// <summary>總筆數，供前端計算頁數。</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>主檔與明細的關聯欄位名稱。</summary>
+    public string RelationColumn { get; set; } = string.Empty;
+
+    /// <summary>當前頁面的明細列。</summary>
+    public List<FormDetailRowViewModel> Rows { get; set; } = new();
+}

--- a/Areas/Form/ViewModels/FormDetailRowViewModel.cs
+++ b/Areas/Form/ViewModels/FormDetailRowViewModel.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace DcMateH5Api.Areas.Form.ViewModels;
+
+/// <summary>
+/// 提供明細列資料給前端顯示或轉移使用。
+/// </summary>
+public class FormDetailRowViewModel
+{
+    /// <summary>明細資料主鍵。</summary>
+    public string? Pk { get; set; }
+
+    /// <summary>欄位與值的對應清單。</summary>
+    public List<FormInputField> Fields { get; set; } = new();
+
+    /// <summary>
+    /// 明細資料中代表主從關聯欄位的設定識別碼，
+    /// 供前端在執行資料搬移時能快速比對對應欄位。
+    /// </summary>
+    public Guid RelationFieldConfigId { get; set; }
+
+    /// <summary>原始資料庫欄位值對應表。</summary>
+    public Dictionary<string, object?> RawData { get; set; } =
+        new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+}

--- a/Areas/Form/ViewModels/FormInputField.cs
+++ b/Areas/Form/ViewModels/FormInputField.cs
@@ -6,6 +6,12 @@ namespace DcMateH5Api.Areas.Form.ViewModels;
 public class FormInputField
 {
     public Guid FieldConfigId { get; set; }
+
+    /// <summary>
+    /// 資料庫欄位名稱，供前端識別欄位用途（例如關聯鍵）。
+    /// </summary>
+    public string? ColumnName { get; set; }
+
     public string? Value { get; set; }
 }
 


### PR DESCRIPTION
## Summary
- surface the relation column's field-config identifier on each detail row so clients can pair pk and relation metadata when moving records
- update the detail row projection logic to reuse the resolved relation config id for both paged and bulk detail queries

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d613747f688320be95dac6e3a3f52c