### PR TITLE
Add primary key flag to form field metadata

### DIFF
--- a/Areas/Form/Services/FormService.cs
+++ b/Areas/Form/Services/FormService.cs
@@ -113,6 +113,7 @@ public class FormService : IFormService
                         DefaultValue = f.DefaultValue,
                         IS_REQUIRED = f.IS_REQUIRED,
                         IS_EDITABLE = f.IS_EDITABLE,
+                        IS_PK = f.IS_PK,
                         ValidationRules = f.ValidationRules,
                         ISUSESQL = f.ISUSESQL,
                         DROPDOWNSQL = f.DROPDOWNSQL,
@@ -233,6 +234,7 @@ public class FormService : IFormService
     {
         var columnTypes = _formDataService.LoadColumnTypes(tableName);
         var configData = _formFieldConfigService.LoadFieldConfigData(masterId);
+        var primaryKeys = _schemaService.GetPrimaryKeyColumns(tableName);
 
         // 只保留可編輯欄位，將不可編輯欄位直接過濾掉以避免出現在前端
         var editableConfigs = configData.FieldConfigs
@@ -242,7 +244,7 @@ public class FormService : IFormService
         var dynamicOptionCache = new Dictionary<Guid, List<FormFieldDropdownOptionsDto>>();
 
         return editableConfigs
-            .Select(cfg => BuildFieldViewModel(cfg, configData, columnTypes, schemaType, dynamicOptionCache))
+            .Select(cfg => BuildFieldViewModel(cfg, configData, columnTypes, schemaType, dynamicOptionCache, primaryKeys))
             .ToList();
     }
 
@@ -251,7 +253,8 @@ public class FormService : IFormService
         FieldConfigData data,
         Dictionary<string, string> columnTypes,
         TableSchemaQueryType schemaType,
-        Dictionary<Guid, List<FormFieldDropdownOptionsDto>> dynamicOptionCache)
+        Dictionary<Guid, List<FormFieldDropdownOptionsDto>> dynamicOptionCache,
+        HashSet<string> primaryKeys)
     {
         var dropdown = data.DropdownConfigs.FirstOrDefault(d => d.FORM_FIELD_CONFIG_ID == field.ID);
         var isUseSql = dropdown?.ISUSESQL ?? false;
@@ -310,6 +313,7 @@ public class FormService : IFormService
             DROPDOWNSQL = dropdown?.DROPDOWNSQL ?? string.Empty,
             DATA_TYPE = dataType,
             SOURCE_TABLE = schemaType,
+            IS_PK = primaryKeys.Contains(field.COLUMN_NAME),
         };
     }
 

--- a/Areas/Form/ViewModels/FormFieldInputViewModel.cs
+++ b/Areas/Form/ViewModels/FormFieldInputViewModel.cs
@@ -12,6 +12,7 @@ public class FormFieldInputViewModel
     public string? DefaultValue { get; set; }
     public bool IS_REQUIRED { get; set; }
     public bool IS_EDITABLE { get; set; }
+    public bool IS_PK { get; set; }
 
     public List<FormFieldValidationRuleDto>? ValidationRules { get; set; }
 


### PR DESCRIPTION
## Summary
- add an `IS_PK` flag to `FormFieldInputViewModel` so API consumers can tell which columns are primary keys
- populate the flag in `FormService` using `_schemaService.GetPrimaryKeyColumns` and keep it when projecting list responses

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcc6fcbf8c8320961ddb6cea4c1df6